### PR TITLE
Convert all handlers to use UTC

### DIFF
--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -4,7 +4,7 @@ import pandas as pd
 from itertools import groupby
 from operator import itemgetter
 from .utils import (
-    datestr_to_datetime,
+    ensure_datetime_with_tz,
     find_registry_key,
     find_registry_key_from_name,
     logging,
@@ -243,7 +243,7 @@ class IMSClient:
                 frames.append(df)
         # df = pd.concat(frames, verify_integrity=True)
         df = pd.concat(frames)
-        df.sort_index(inplace=True)
+        df = df.tz_convert(self.tz).sort_index()
         # read_type INT leads to overlapping values after concatenating
         # due to both start time and end time included.
         # Aggregate read_types (should) align perfectly and don't
@@ -307,8 +307,8 @@ class IMSClient:
                 "Unable to read raw/sampled data for multiple tags since they don't "
                 "share time vector"
             )
-        start_time = datestr_to_datetime(start_time, tz=self.tz)
-        stop_time = datestr_to_datetime(stop_time, tz=self.tz)
+        start_time = ensure_datetime_with_tz(start_time, tz=self.tz)
+        stop_time = ensure_datetime_with_tz(stop_time, tz=self.tz)
         if not isinstance(ts, pd.Timedelta):
             ts = pd.Timedelta(ts, unit="s")
 

--- a/tagreader/utils.py
+++ b/tagreader/utils.py
@@ -39,16 +39,12 @@ def find_registry_key_from_name(base_key, search_key_name):
     return key, key_string
 
 
-def datestr_to_datetime(date_stamp, tz="Europe/Oslo"):
-    date_stamp = (
-        pd.to_datetime(date_stamp, dayfirst=True).tz_localize(tz)
-        if isinstance(date_stamp, str)
-        else date_stamp
-    )
+def ensure_datetime_with_tz(date_stamp, tz="Europe/Oslo"):
+    if isinstance(date_stamp, str):
+        date_stamp = pd.to_datetime(date_stamp, dayfirst=True)
+
     if not date_stamp.tzinfo:
         date_stamp = date_stamp.tz_localize(tz)
-    else:
-        date_stamp = date_stamp.tz_convert(tz)
     return date_stamp
 
 

--- a/tagreader/web_handlers.py
+++ b/tagreader/web_handlers.py
@@ -402,11 +402,7 @@ class AspenHandlerWeb:
             .rename(columns={"t": "Timestamp", "v": "Value"})
         )
         df["Timestamp"] = pd.to_datetime(df["Timestamp"], unit="ms", origin="unix")
-        df = (
-            df.set_index("Timestamp", drop=True)
-            .tz_localize("UTC")
-            .tz_convert(start_time.tzinfo)
-        )
+        df = df.set_index("Timestamp", drop=True).tz_localize("UTC")
         df.index.name = "time"
         return df.rename(columns={"Value": tag})
 
@@ -475,6 +471,9 @@ class PIHandlerWeb:
     def generate_read_query(
         self, tag, start_time, stop_time, sample_time, read_type, metadata=None
     ):
+        start_time = start_time.tz_convert("UTC")
+        stop_time = stop_time.tz_convert("UTC")
+
         if read_type in [
             ReaderType.COUNT,
             ReaderType.GOOD,
@@ -504,6 +503,7 @@ class PIHandlerWeb:
 
         params["startTime"] = starttime
         params["endTime"] = stoptime
+        params["timeZone"] = "UTC"
 
         summary_type = {
             ReaderType.MIN: "Minimum",
@@ -682,6 +682,6 @@ class PIHandlerWeb:
 
         df = df.set_index("Timestamp", drop=True)
         df.index.name = "time"
-        df = df.tz_localize("UTC").tz_convert(start_time.tzinfo)
+        df = df.tz_localize("UTC")
 
         return df.rename(columns={"Value": tag})

--- a/tests/test_AspenHandlerODBC.py
+++ b/tests/test_AspenHandlerODBC.py
@@ -14,16 +14,15 @@ def test_generate_connection_string():
 
 
 def test_generate_tag_read_query():
-    start_time = utils.datestr_to_datetime("2018-01-17 16:00:00")
-    stop_time = utils.datestr_to_datetime("2018-01-17 17:00:00")
+    start_time = utils.ensure_datetime_with_tz("2018-01-17 16:00:00")
+    stop_time = utils.ensure_datetime_with_tz("2018-01-17 17:00:00")
     ts = pd.Timedelta(1, unit="m")
     res = AspenHandlerODBC.generate_read_query(
         "thetag", None, start_time, stop_time, ts, ReaderType.INT
     )
     expected = (
-        "SELECT CAST(ts AS CHAR FORMAT 'YYYY-MM-DD HH:MI:SS') AS \"time\", "
-        'value AS "value" FROM history WHERE name = '
-        "'thetag' AND (ts BETWEEN '17-Jan-18 16:00:00' AND '17-Jan-18 17:00:00') AND "
-        "(request = 7) AND (period = 600) ORDER BY ts"
+        'SELECT ISO8601(ts) AS "time", value AS "value" FROM history WHERE name = '
+        "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+        "AND (request = 7) AND (period = 600) ORDER BY ts"
     )
     assert expected == res

--- a/tests/test_AspenHandlerREST.py
+++ b/tests/test_AspenHandlerREST.py
@@ -91,8 +91,8 @@ def test_generate_map_query(AspenHandler):
     ],
 )
 def test_generate_tag_read_query(AspenHandler, read_type):
-    start_time = utils.datestr_to_datetime("2020-06-24 17:00:00")
-    stop_time = utils.datestr_to_datetime("2020-06-24 18:00:00")
+    start_time = utils.ensure_datetime_with_tz("2020-06-24 17:00:00")
+    stop_time = utils.ensure_datetime_with_tz("2020-06-24 18:00:00")
     ts = pd.Timedelta(1, unit="m")
     res = AspenHandler.generate_read_query(
         "ATCAI", None, start_time, stop_time, ts, getattr(ReaderType, read_type)

--- a/tests/test_PIHandlerODBC.py
+++ b/tests/test_PIHandlerODBC.py
@@ -18,22 +18,23 @@ def test_generate_connection_string(PIHandler):
     expected = (
         "DRIVER={PI ODBC Driver};Server=das_server;Trusted_Connection=Yes;"
         "Command Timeout=1800;Provider Type=PIOLEDB;"
-        "Provider String={Data source=thehostname;Integrated_Security=SSPI;};"
+        "Provider String={Data source=thehostname;Integrated_Security=SSPI;"
+        "Time Zone=UTC};"
     )
     assert expected == res
 
 
 def test_generate_tag_read_query(PIHandler):
-    start_time = utils.datestr_to_datetime("2018-01-17 16:00:00")
-    stop_time = utils.datestr_to_datetime("2018-01-17 17:00:00")
+    start_time = utils.ensure_datetime_with_tz("2018-01-17 16:00:00")
+    stop_time = utils.ensure_datetime_with_tz("2018-01-17 17:00:00")
     ts = pd.Timedelta(1, unit="m")
     res = PIHandler.generate_read_query(
         "thetag", start_time, stop_time, ts, ReaderType.INT
     )
     expected = (
-        "SELECT CAST(value as FLOAT32) AS value, __utctime AS timestamp "
+        "SELECT CAST(value as FLOAT32) AS value, time "
         "FROM [piarchive]..[piinterp2] WHERE tag='thetag' "
-        "AND (time BETWEEN '17-Jan-18 16:00:00' AND '17-Jan-18 17:00:00') "
-        "AND (timestep = '60s') ORDER BY timestamp"
+        "AND (time BETWEEN '17-Jan-18 15:00:00' AND '17-Jan-18 16:00:00') "
+        "AND (timestep = '60s') ORDER BY time"
     )
     assert expected == res

--- a/tests/test_PIHandlerODBC_connect.py
+++ b/tests/test_PIHandlerODBC_connect.py
@@ -1,10 +1,7 @@
 import pytest
 import os
 import pandas as pd
-from tagreader.utils import (
-    ReaderType,
-    datestr_to_datetime
-)
+from tagreader.utils import ReaderType, ensure_datetime_with_tz
 from tagreader.odbc_handlers import list_pi_sources
 from tagreader.clients import IMSClient
 
@@ -87,7 +84,7 @@ def test_read(Client, read_type, size):
         tags["Float32"], interval[0], interval[1], 60, getattr(ReaderType, read_type)
     )
     assert df.shape == (size, 1)
-    assert df.index[0] == datestr_to_datetime(interval[0])
+    assert df.index[0] == ensure_datetime_with_tz(interval[0])
     assert df.index[size - 1] == df.index[0] + (size - 1) * pd.Timedelta(60, unit="s")
 
 

--- a/tests/test_PIHandlerREST.py
+++ b/tests/test_PIHandlerREST.py
@@ -1,9 +1,6 @@
 import pytest
 import pandas as pd
-from tagreader.utils import (
-    datestr_to_datetime,
-    ReaderType
-)
+from tagreader.utils import ensure_datetime_with_tz, ReaderType
 from tagreader.web_handlers import PIHandlerWeb
 
 START_TIME = "2020-04-01 11:05:00"
@@ -79,8 +76,8 @@ def test_is_summary(PIHandler):
     ],
 )
 def test_generate_read_query(PIHandler, read_type):  # TODO: Move away from test*connect
-    starttime = datestr_to_datetime(START_TIME)
-    stoptime = datestr_to_datetime(STOP_TIME)
+    starttime = ensure_datetime_with_tz(START_TIME)
+    stoptime = ensure_datetime_with_tz(STOP_TIME)
     ts = pd.Timedelta(SAMPLE_TIME, unit="s")
 
     (url, params) = PIHandler.generate_read_query(
@@ -90,16 +87,21 @@ def test_generate_read_query(PIHandler, read_type):  # TODO: Move away from test
         ts,
         getattr(ReaderType, read_type),
     )
-    assert params["startTime"] == "01-Apr-20 11:05:00"
-    assert params["endTime"] == "01-Apr-20 12:05:00"
+    assert params["startTime"] == "01-Apr-20 09:05:00"
+    assert params["endTime"] == "01-Apr-20 10:05:00"
 
     if read_type == "INT":
         assert url == f"streams/{PIHandler.webidcache['alreadyknowntag']}/interpolated"
-        assert params["selectedFields"] == "Links;Items.Timestamp;Items.Value;Items.Good"
+        assert (
+            params["selectedFields"] == "Links;Items.Timestamp;Items.Value;Items.Good"
+        )
         assert params["interval"] == f"{SAMPLE_TIME}s"
     elif read_type in ["AVG", "MIN", "MAX", "RNG", "STD", "VAR"]:
         assert url == f"streams/{PIHandler.webidcache['alreadyknowntag']}/summary"
-        assert params["selectedFields"] == "Links;Items.Value.Timestamp;Items.Value.Value;Items.Value.Good"
+        assert (
+            params["selectedFields"]
+            == "Links;Items.Value.Timestamp;Items.Value.Value;Items.Value.Good"
+        )
         assert {
             "AVG": "Average",
             "MIN": "Minimum",

--- a/tests/test_data_integrity.py
+++ b/tests/test_data_integrity.py
@@ -2,7 +2,7 @@ import os
 import pytest
 import pandas as pd
 from tagreader import IMSClient
-from tagreader.utils import ReaderType, datestr_to_datetime
+from tagreader.utils import ReaderType, ensure_datetime_with_tz
 from tagreader.cache import SmartCache
 
 is_GITHUBACTION = "GITHUB_ACTION" in os.environ
@@ -177,7 +177,7 @@ def test_cache_proper_fill_up(PIClientWeb):
         PI_TAG,
         ReaderType.INT,
         TS,
-        datestr_to_datetime(PI_START_TIME),
-        datestr_to_datetime(PI_END_TIME_2),
+        ensure_datetime_with_tz(PI_START_TIME),
+        ensure_datetime_with_tz(PI_END_TIME_2),
     )
     assert len(df_cached) == 32

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,24 +2,31 @@ import datetime
 from pytz import timezone
 
 from tagreader.utils import (
-    datestr_to_datetime,
+    ensure_datetime_with_tz,
     urljoin,
 )
 
 
-def test_datestr_to_datetime():
-    assert datestr_to_datetime("10. jan. 2018 13:45:15") == timezone(
+def test_ensure_is_datetime():
+    assert ensure_datetime_with_tz("10. jan. 2018 13:45:15") == timezone(
         "Europe/Oslo"
     ).localize(datetime.datetime(2018, 1, 10, 13, 45, 15))
-    assert datestr_to_datetime("02.01.03 00:00:00") == timezone(
+    assert ensure_datetime_with_tz("02.01.03 00:00:00") == timezone(
         "Europe/Oslo"
     ).localize(datetime.datetime(2003, 1, 2, 0, 0, 0))
-    assert datestr_to_datetime("02.01.03 00:00:00") == datestr_to_datetime(
+    assert ensure_datetime_with_tz("02.01.03 00:00:00") == ensure_datetime_with_tz(
         "2003-02-01 0:00:00am"
     )
-    assert datestr_to_datetime(
+    assert ensure_datetime_with_tz(
         "02.01.03 00:00:00", "America/Sao_Paulo"
     ) == timezone("America/Sao_Paulo").localize(datetime.datetime(2003, 1, 2, 0, 0, 0))
+    assert ensure_datetime_with_tz("02.01.03 00:00:00", tz="Brazil/East") == timezone(
+        "Brazil/East"
+    ).localize(datetime.datetime(2003, 1, 2, 0, 0, 0))
+    assert ensure_datetime_with_tz(
+        timezone("Brazil/East").localize(datetime.datetime(2003, 1, 2, 0, 0, 0)),
+        tz="Europe/Oslo",
+    ) == timezone("Brazil/East").localize(datetime.datetime(2003, 1, 2, 0, 0, 0))
 
 
 def test_urljoin():


### PR DESCRIPTION
Unify handling of time zones among the four handlers by always querying for UTC time and returning dataframe with timezone that makes sense.