### PR TITLE
Add support for snapshot readertype

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ To install and/or upgrade:
 pip install --upgrade tagreader
 ```
 
-If you wish to use ODBC connections to the IMS servers, you will also need some drivers. Check the [manual](docs/manual.md).
+If you wish to use ODBC connections to the IMS servers, you will also need some proprietary drivers. There is more information in the [manual](docs/manual.md#odbc-drivers).
 
 ## Documentation
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -215,7 +215,7 @@ Data is read by calling the client method `read()` with the following input argu
 * `start_time` : Start of time period. 
 * `stop_time` : End of time period. 
 
-  Both `start_time` and `stop time` can be either string (which will be interpreted by [pandas. Timestamp](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Timestamp.html) or datetime object.
+  Both `start_time` and `stop time` can be either datetime object or string. Strings are interpreted by the [Timestamp](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Timestamp.html) method from Pandas.
 
 * `ts` : The interval between samples when querying interpolated or aggregated data.
 * `read_type` (optional): What kind of data to read. **Default*** Interpolated. 
@@ -271,6 +271,8 @@ There are two levels of determining which time zone input arguments should be in
 2. Time zone naive input arguments are assumed to have time zone as provided by the client. 
 
 The client-provided time zone can be specified with the optional `tz` argument (string, e.g. "*US/Central*") during client creation. If it is not specified, then the default value *Europe/Oslo* is used. Note that for the most common use case where Equinor employees want to fetch data from Norwegian assets and display them with Norwegian time stamps, nothing needs to be done.
+
+*Note:* It is a good idea to update the `pytz` package rather frequently (at least twice per year) to ensure that time zone information is up to date. `pip install --upgrade pytz`.
 
 **Example (advanced usage)**
 

--- a/docs/quickstart.ipynb
+++ b/docs/quickstart.ipynb
@@ -158,7 +158,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Selecting three of the tags found above, we can read values for a duration of 3.5 hours starting January 5th at 8 in the morning with 3-minute (180-seconds) intervals. The default query method is interpolated. Timestamps are parsed using [pandas.Timestamp](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Timestamp.html), and can therefore be provided in many different string formats. [More details](./manual.md#reading_data)"
+    "Selecting three of the tags found above, we can read values for a duration of 3.5 hours starting January 5th at 8 in the morning with 3-minute (180-seconds) intervals. The default query method is interpolated, but several other methods are available by providing the `read_type` argument. Timestamps are parsed using [pandas.Timestamp](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Timestamp.html), and can therefore be provided in many different string formats. [More details](./manual.md#reading_data)"
    ]
   },
   {

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -372,6 +372,7 @@ class IMSClient:
             )
         if read_type != ReaderType.SNAPSHOT:
             start_time = ensure_datetime_with_tz(start_time, tz=self.tz)
+        if end_time:
             end_time = ensure_datetime_with_tz(end_time, tz=self.tz)
         if not isinstance(ts, pd.Timedelta):
             ts = pd.Timedelta(ts, unit="s")

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -257,7 +257,9 @@ class IMSClient:
     def _read_single_tag(self, tag, start_time, stop_time, ts, read_type, cache=None):
         if read_type == ReaderType.SNAPSHOT:
             metadata = self._get_metadata(tag)
-            df = self.handler.read_tag(tag, start_time, stop_time, ts, read_type, metadata)
+            df = self.handler.read_tag(
+                tag, start_time, stop_time, ts, read_type, metadata
+            )
         else:
             missing_intervals = [(start_time, stop_time)]
             df = pd.DataFrame()
@@ -347,7 +349,9 @@ class IMSClient:
             read_type=read_type,
         )
 
-    def read(self, tags, start_time=None, end_time=None, ts=60, read_type=ReaderType.INT):
+    def read(
+        self, tags, start_time=None, end_time=None, ts=60, read_type=ReaderType.INT
+    ):
         """Reads values for the specified [tags] from the IMS server for the
         time interval from [start_time] to [stop_time] in intervals [ts].
 
@@ -361,14 +365,14 @@ class IMSClient:
             from utils import ReaderType
 
         Values for Readertype.* that should work are:
-            INT, MIN, MAX, RNG, AVG, VAR and STD
+            INT, MIN, MAX, RNG, AVG, VAR, STD and SNAPSHOT
         """
         if isinstance(tags, str):
             tags = [tags]
-        if read_type == ReaderType.SAMPLED and len(tags) > 1:
+        if read_type in [ReaderType.RAW, ReaderType.SNAPSHOT] and len(tags) > 1:
             raise RuntimeError(
                 "Unable to read raw/sampled data for multiple tags since they don't "
-                "share time vector"
+                "share time vector. Read one at a time."
             )
         if read_type != ReaderType.SNAPSHOT:
             start_time = ensure_datetime_with_tz(start_time, tz=self.tz)

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -258,7 +258,7 @@ class IMSClient:
         if read_type == ReaderType.SNAPSHOT:
             metadata = self._get_metadata(tag)
             df = self.handler.read_tag(tag, start_time, stop_time, ts, read_type, metadata)
-        else:    
+        else:
             missing_intervals = [(start_time, stop_time)]
             df = pd.DataFrame()
             if cache is not None:
@@ -342,12 +342,12 @@ class IMSClient:
         return self.read(
             tags=tags,
             start_time=start_time,
-            stop_time=stop_time,
+            end_time=stop_time,
             ts=ts,
             read_type=read_type,
         )
 
-    def read(self, tags, start_time, stop_time, ts, read_type=ReaderType.INT):
+    def read(self, tags, start_time=None, end_time=None, ts=60, read_type=ReaderType.INT):
         """Reads values for the specified [tags] from the IMS server for the
         time interval from [start_time] to [stop_time] in intervals [ts].
 
@@ -370,8 +370,9 @@ class IMSClient:
                 "Unable to read raw/sampled data for multiple tags since they don't "
                 "share time vector"
             )
-        start_time = ensure_datetime_with_tz(start_time, tz=self.tz)
-        stop_time = ensure_datetime_with_tz(stop_time, tz=self.tz)
+        if read_type != ReaderType.SNAPSHOT:
+            start_time = ensure_datetime_with_tz(start_time, tz=self.tz)
+            end_time = ensure_datetime_with_tz(end_time, tz=self.tz)
         if not isinstance(ts, pd.Timedelta):
             ts = pd.Timedelta(ts, unit="s")
 
@@ -379,7 +380,7 @@ class IMSClient:
         for tag in tags:
             cols.append(
                 self._read_single_tag(
-                    tag, start_time, stop_time, ts, read_type, cache=self.cache
+                    tag, start_time, end_time, ts, read_type, cache=self.cache
                 )
             )
         return pd.concat(cols, axis=1)

--- a/tagreader/odbc_handlers.py
+++ b/tagreader/odbc_handlers.py
@@ -70,9 +70,7 @@ class AspenHandlerODBC:
         return f"DRIVER={{AspenTech SQLPlus}};HOST={host};PORT={port};READONLY=Y;MAXROWS={max_rows}"  # noqa: E501
 
     @staticmethod
-    def generate_read_query(
-        tag, mapdef, start_time, stop_time, sample_time, read_type
-    ):
+    def generate_read_query(tag, mapdef, start_time, stop_time, sample_time, read_type):
         if mapdef is None:
             mapdef = {}
         if read_type in [
@@ -129,7 +127,7 @@ class AspenHandlerODBC:
 
         ts = "ts"
         if from_column == "aggregates":
-            ts = "ts_start" 
+            ts = "ts_start"
         elif read_type == ReaderType.SNAPSHOT:
             ts = mapdef.get("MAP_CurrentTimeStamp", "IP_INPUT_TIME")
 
@@ -201,10 +199,10 @@ class AspenHandlerODBC:
         temp = [dict(zip(colnames, row)) for row in rows]
         mapdef = {}
         for t in temp:
-            if t['tagname'] not in mapdef:
-                mapdef[t['tagname']] = [t]
+            if t["tagname"] not in mapdef:
+                mapdef[t["tagname"]] = [t]
             else:
-                mapdef[t['tagname']].append(t)
+                mapdef[t["tagname"]].append(t)
         return mapdef
 
     @staticmethod
@@ -247,7 +245,6 @@ class AspenHandlerODBC:
         return None
 
     def _get_default_mapdef(self, tagname):
-        #(tagname, _) = tagname.split(";") if ";" in tagname else (tagname, None)
         mapdefs = self._get_mapdefs(tagname)
         for mapdef in mapdefs:
             if mapdef["MAP_IsDefault"] == "TRUE":

--- a/tagreader/odbc_handlers.py
+++ b/tagreader/odbc_handlers.py
@@ -71,8 +71,10 @@ class AspenHandlerODBC:
 
     @staticmethod
     def generate_read_query(
-        tag, mapping, start_time, stop_time, sample_time, read_type
+        tag, mapdef, start_time, stop_time, sample_time, read_type
     ):
+        if mapdef is None:
+            mapdef = {}
         if read_type in [
             ReaderType.COUNT,
             ReaderType.GOOD,
@@ -125,12 +127,11 @@ class AspenHandlerODBC:
         # For RAW: historyevent?
         # Ref https://help.sap.com/saphelp_pco151/helpdata/en/4c/72e34ee631469ee10000000a15822d/content.htm?no_cache=true  # noqa: E501
 
+        ts = "ts"
         if from_column == "aggregates":
             ts = "ts_start" 
         elif read_type == ReaderType.SNAPSHOT:
-            ts = "IP_INPUT_TIME"
-        else:
-            ts = "ts"
+            ts = mapdef.get("MAP_CurrentTimeStamp", "IP_INPUT_TIME")
 
         value = {
             ReaderType.MIN: "min",
@@ -143,7 +144,7 @@ class AspenHandlerODBC:
             ReaderType.NOTGOOD: "ng",
             ReaderType.TOTAL: "sum",
             ReaderType.SUM: "sum",
-            ReaderType.SNAPSHOT: "IP_INPUT_VALUE",
+            ReaderType.SNAPSHOT: mapdef.get("MAP_CurrentValue", "IP_INPUT_VALUE"),
         }.get(read_type, "value")
 
         query = [
@@ -155,8 +156,8 @@ class AspenHandlerODBC:
             start = start_time.strftime(timecast_format_query)
             stop = stop_time.strftime(timecast_format_query)
             query.extend([f"WHERE name = {tag!r}"])
-            if mapping is not None:
-                query.extend([f"AND FIELD_ID = FT({mapping!r})"])
+            if mapdef:
+                query.extend([f'AND FIELD_ID = FT({mapdef["MAP_HistoryValue"]!r})'])
             query.extend(
                 [
                     f"AND (ts BETWEEN {start!r} AND {stop!r})",
@@ -177,7 +178,7 @@ class AspenHandlerODBC:
         self.cursor = self.conn.cursor()
 
     @staticmethod
-    def _generate_query_get_mapdef_for_tag(tag):
+    def _generate_query_get_mapdef_for_search(tag):
         query = [
             "SELECT DISTINCT a.name as tagname, m.NAME, m.MAP_DefinitionRecord,",
             "m.MAP_IsDefault, m.MAP_Description, m.MAP_Units, m.MAP_Base, m.MAP_Range",
@@ -192,6 +193,20 @@ class AspenHandlerODBC:
         query.append("AND m.MAP_IsDefault = 'TRUE'")
         return " ".join(query)
 
+    def _get_mapdef_for_search(self, tag):
+        query = self._generate_query_get_mapdef_for_search(tag)
+        self.cursor.execute(query)
+        colnames = [col[0] for col in self.cursor.description]
+        rows = self.cursor.fetchall()
+        temp = [dict(zip(colnames, row)) for row in rows]
+        mapdef = {}
+        for t in temp:
+            if t['tagname'] not in mapdef:
+                mapdef[t['tagname']] = [t]
+            else:
+                mapdef[t['tagname']].append(t)
+        return mapdef
+
     @staticmethod
     def _generate_query_search_tag(mapdef, desc=None):
         if mapdef["MAP_DefinitionRecord"] is None:
@@ -205,31 +220,39 @@ class AspenHandlerODBC:
             query.append(f"AND {mapdef['MAP_Description']} like '{desc}'")
         return " ".join(query)
 
-    def _get_mapdef(self, tag):
-        query = self._generate_query_get_mapdef_for_tag(tag)
+    @staticmethod
+    def _generate_query_get_mapdefs(tag):
+        query = [
+            "SELECT m.NAME, m.MAP_DefinitionRecord, m.MAP_IsDefault,",
+            "m.MAP_Description, m.MAP_Units, m.MAP_Base, m.MAP_Range,",
+            "m.MAP_CurrentValue, m.MAP_CurrentTimeStamp, m.MAP_CurrentQuality,",
+            f'm.MAP_HistoryValue FROM "{tag}" t',
+            "LEFT JOIN atmapdef m ON t.definition = m.MAP_DefinitionRecord",
+        ]
+        return " ".join(query)
+
+    def _get_mapdefs(self, tag):
+        query = self._generate_query_get_mapdefs(tag)
         self.cursor.execute(query)
         colnames = [col[0] for col in self.cursor.description]
         rows = self.cursor.fetchall()
-        temp = [dict(zip(colnames, row)) for row in rows]
-        mapdef = {}
-        for t in temp:
-            if t["tagname"] not in mapdef:
-                mapdef[t["tagname"]] = [t]
-            else:
-                mapdef[t["tagname"]].append(t)
-        return mapdef
+        mapdefs = [dict(zip(colnames, row)) for row in rows]
+        return mapdefs
 
     def _get_specific_mapdef(self, tagname, mapping):
-        mapdef = self._get_mapdef(tagname)
-        for m in mapdef[tagname]:
-            if m["NAME"] == mapping:
-                return m
+        mapdefs = self._get_mapdefs(tagname)
+        for mapdef in mapdefs:
+            if mapdef["NAME"].lower() == mapping.lower():
+                return mapdef
         return None
 
     def _get_default_mapdef(self, tagname):
-        (tagname, _) = tagname.split(";") if ";" in tagname else (tagname, None)
-        mapdef = self._get_mapdef(tagname)
-        return mapdef[tagname][0]
+        #(tagname, _) = tagname.split(";") if ";" in tagname else (tagname, None)
+        mapdefs = self._get_mapdefs(tagname)
+        for mapdef in mapdefs:
+            if mapdef["MAP_IsDefault"] == "TRUE":
+                return mapdef
+        return None
 
     def search(self, tag=None, desc=None):
         if tag is None:
@@ -238,7 +261,7 @@ class AspenHandlerODBC:
         tag = tag.replace("*", "%") if isinstance(tag, str) else None
         desc = desc.replace("*", "%") if isinstance(desc, str) else None
 
-        mapdef = self._get_mapdef(tag)
+        mapdef = self._get_mapdef_for_search(tag)
 
         res = []
         for tagname in mapdef:  # TODO: Refactor
@@ -265,10 +288,10 @@ class AspenHandlerODBC:
     def _get_tag_unit(self, tag):
         (tagname, mapping) = tag.split(";") if ";" in tag else (tag, None)
         if mapping is None:
-            mapping = self._get_default_mapdef(tagname)
+            mapdef = self._get_default_mapdef(tagname)
         else:
-            mapping = self._get_specific_mapdef(tagname, mapping)
-        query = f"SELECT name, \"{mapping['MAP_Units']}\" as engunit FROM \"{tagname}\""
+            mapdef = self._get_specific_mapdef(tagname, mapping)
+        query = f"SELECT name, \"{mapdef['MAP_Units']}\" as engunit FROM \"{tagname}\""
         self.cursor.execute(query)
         res = self.cursor.fetchone()
         if not res.engunit:
@@ -287,18 +310,18 @@ class AspenHandlerODBC:
         ]
         query = " ".join(query)
         self.cursor.execute(query)
-        res = self.cursor.fetchall()
-        return res[0][1]
+        res = self.cursor.fetchone()
+        if not res.description:
+            res.description = ""
+        return res.description
 
     def read_tag(self, tag, start_time, stop_time, sample_time, read_type, metadata):
         (cleantag, mapping) = tag.split(";") if ";" in tag else (tag, None)
-        map_historyvalue = None
+        mapdef = dict()
         if mapping is not None:
-            c = self.conn.cursor()
-            c.execute(f'SELECT MAP_HistoryValue FROM "{mapping}"')
-            map_historyvalue = c.fetchone()[0]
+            mapdef = self._get_specific_mapdef(cleantag, mapping)
         query = self.generate_read_query(
-            cleantag, map_historyvalue, start_time, stop_time, sample_time, read_type
+            cleantag, mapdef, start_time, stop_time, sample_time, read_type
         )
         # logging.debug(f'Executing SQL query {query!r}')
         df = pd.read_sql(

--- a/tagreader/web_handlers.py
+++ b/tagreader/web_handlers.py
@@ -511,7 +511,7 @@ class PIHandlerWeb:
         get_action = {
             ReaderType.INT: "interpolated",
             ReaderType.RAW: "recorded",
-            ReaderType.SNAPSHOT: "end",
+            ReaderType.SNAPSHOT: "value",
             ReaderType.SHAPEPRESERVING: "plot",
         }.get(read_type, "summary")
 
@@ -523,6 +523,11 @@ class PIHandlerWeb:
                 timecast_format_query
             )
             params["endTime"] = stop_time.tz_convert("UTC").strftime(
+                timecast_format_query
+            )
+            params["timeZone"] = "UTC"
+        elif read_type == ReaderType.SNAPSHOT and stop_time is not None:
+            params["time"] = stop_time.tz_convert("UTC").strftime(
                 timecast_format_query
             )
             params["timeZone"] = "UTC"

--- a/tests/test_AspenHandlerODBC.py
+++ b/tests/test_AspenHandlerODBC.py
@@ -56,44 +56,44 @@ def test_generate_tag_read_query(read_type):
 
     expected = {
         "INT": (
-            'SELECT ISO8601(ts) AS "time", value AS "value" FROM history WHERE name = '
-            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
-            "AND (request = 7) AND (period = 600) ORDER BY ts"
+            'SELECT ISO8601(ts) AS "time", value AS "value" FROM history WHERE '
+            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
+            "'2018-01-17T16:00:00Z') AND (request = 7) AND (period = 600) ORDER BY ts"
         ),
         "MIN": (
-            'SELECT ISO8601(ts_start) AS "time", min AS "value" FROM aggregates WHERE name = '
-            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
-            "AND (request = 1) AND (period = 600) ORDER BY ts"
+            'SELECT ISO8601(ts_start) AS "time", min AS "value" FROM aggregates WHERE '
+            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
+            "'2018-01-17T16:00:00Z') AND (request = 1) AND (period = 600) ORDER BY ts"
         ),
         "MAX": (
-            'SELECT ISO8601(ts_start) AS "time", max AS "value" FROM aggregates WHERE name = '
-            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
-            "AND (request = 1) AND (period = 600) ORDER BY ts"
+            'SELECT ISO8601(ts_start) AS "time", max AS "value" FROM aggregates WHERE '
+            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
+            "'2018-01-17T16:00:00Z') AND (request = 1) AND (period = 600) ORDER BY ts"
         ),
         "RNG": (
-            'SELECT ISO8601(ts_start) AS "time", rng AS "value" FROM aggregates WHERE name = '
-            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
-            "AND (request = 1) AND (period = 600) ORDER BY ts"
+            'SELECT ISO8601(ts_start) AS "time", rng AS "value" FROM aggregates WHERE '
+            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
+            "'2018-01-17T16:00:00Z') AND (request = 1) AND (period = 600) ORDER BY ts"
         ),
         "AVG": (
-            'SELECT ISO8601(ts_start) AS "time", avg AS "value" FROM aggregates WHERE name = '
-            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
-            "AND (request = 1) AND (period = 600) ORDER BY ts"
+            'SELECT ISO8601(ts_start) AS "time", avg AS "value" FROM aggregates WHERE '
+            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
+            "'2018-01-17T16:00:00Z') AND (request = 1) AND (period = 600) ORDER BY ts"
         ),
         "STD": (
-            'SELECT ISO8601(ts_start) AS "time", std AS "value" FROM aggregates WHERE name = '
-            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
-            "AND (request = 1) AND (period = 600) ORDER BY ts"
+            'SELECT ISO8601(ts_start) AS "time", std AS "value" FROM aggregates WHERE '
+            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
+            "'2018-01-17T16:00:00Z') AND (request = 1) AND (period = 600) ORDER BY ts"
         ),
         "VAR": (
-            'SELECT ISO8601(ts_start) AS "time", var AS "value" FROM aggregates WHERE name = '
-            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
-            "AND (request = 1) AND (period = 600) ORDER BY ts"
+            'SELECT ISO8601(ts_start) AS "time", var AS "value" FROM aggregates WHERE '
+            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
+            "'2018-01-17T16:00:00Z') AND (request = 1) AND (period = 600) ORDER BY ts"
         ),
         "SNAPSHOT": (
-            'SELECT ISO8601(IP_INPUT_TIME) AS "time", IP_INPUT_VALUE AS "value" FROM "thetag"'
+            'SELECT ISO8601(IP_INPUT_TIME) AS "time", IP_INPUT_VALUE AS "value" '
+            'FROM "thetag"'
         ),
-
     }
 
     assert expected[read_type] == res

--- a/tests/test_AspenHandlerODBC.py
+++ b/tests/test_AspenHandlerODBC.py
@@ -1,7 +1,12 @@
+import pytest
 import pandas as pd
 from tagreader import utils
 from tagreader.utils import ReaderType
 from tagreader.odbc_handlers import AspenHandlerODBC
+
+START_TIME = "2018-01-17 16:00:00"
+STOP_TIME = "2018-01-17 17:00:00"
+SAMPLE_TIME = 60
 
 
 def test_generate_connection_string():
@@ -13,16 +18,82 @@ def test_generate_connection_string():
     assert expected == res
 
 
-def test_generate_tag_read_query():
-    start_time = utils.ensure_datetime_with_tz("2018-01-17 16:00:00")
-    stop_time = utils.ensure_datetime_with_tz("2018-01-17 17:00:00")
-    ts = pd.Timedelta(1, unit="m")
-    res = AspenHandlerODBC.generate_read_query(
-        "thetag", None, start_time, stop_time, ts, ReaderType.INT
-    )
-    expected = (
-        'SELECT ISO8601(ts) AS "time", value AS "value" FROM history WHERE name = '
-        "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
-        "AND (request = 7) AND (period = 600) ORDER BY ts"
-    )
-    assert expected == res
+@pytest.mark.parametrize(
+    "read_type",
+    [
+        # pytest.param("RAW", marks=pytest.mark.skip(reason="Not implemented")),
+        # pytest.param(
+        #     "SHAPEPRESERVING", marks=pytest.mark.skip(reason="Not implemented")
+        # ),
+        "INT",
+        "MIN",
+        "MAX",
+        "RNG",
+        "AVG",
+        "STD",
+        "VAR",
+        # pytest.param("COUNT", marks=pytest.mark.skip(reason="Not implemented")),
+        # pytest.param("GOOD", marks=pytest.mark.skip(reason="Not implemented")),
+        # pytest.param("BAD", marks=pytest.mark.skip(reason="Not implemented")),
+        # pytest.param("TOTAL", marks=pytest.mark.skip(reason="Not implemented")),
+        # pytest.param("SUM", marks=pytest.mark.skip(reason="Not implemented")),
+        "SNAPSHOT",
+    ],
+)
+def test_generate_tag_read_query(read_type):
+    starttime = utils.ensure_datetime_with_tz(START_TIME)
+    stoptime = utils.ensure_datetime_with_tz(STOP_TIME)
+    ts = pd.Timedelta(SAMPLE_TIME, unit="s")
+
+    if read_type == "SNAPSHOT":
+        res = AspenHandlerODBC.generate_read_query(
+            "thetag", None, None, None, None, getattr(ReaderType, read_type)
+        )
+    else:
+        res = AspenHandlerODBC.generate_read_query(
+            "thetag", None, starttime, stoptime, ts, getattr(ReaderType, read_type)
+        )
+
+    expected = {
+        "INT": (
+            'SELECT ISO8601(ts) AS "time", value AS "value" FROM history WHERE name = '
+            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "AND (request = 7) AND (period = 600) ORDER BY ts"
+        ),
+        "MIN": (
+            'SELECT ISO8601(ts_start) AS "time", min AS "value" FROM aggregates WHERE name = '
+            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "AND (request = 1) AND (period = 600) ORDER BY ts"
+        ),
+        "MAX": (
+            'SELECT ISO8601(ts_start) AS "time", max AS "value" FROM aggregates WHERE name = '
+            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "AND (request = 1) AND (period = 600) ORDER BY ts"
+        ),
+        "RNG": (
+            'SELECT ISO8601(ts_start) AS "time", rng AS "value" FROM aggregates WHERE name = '
+            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "AND (request = 1) AND (period = 600) ORDER BY ts"
+        ),
+        "AVG": (
+            'SELECT ISO8601(ts_start) AS "time", avg AS "value" FROM aggregates WHERE name = '
+            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "AND (request = 1) AND (period = 600) ORDER BY ts"
+        ),
+        "STD": (
+            'SELECT ISO8601(ts_start) AS "time", std AS "value" FROM aggregates WHERE name = '
+            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "AND (request = 1) AND (period = 600) ORDER BY ts"
+        ),
+        "VAR": (
+            'SELECT ISO8601(ts_start) AS "time", var AS "value" FROM aggregates WHERE name = '
+            "'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "AND (request = 1) AND (period = 600) ORDER BY ts"
+        ),
+        "SNAPSHOT": (
+            'SELECT ISO8601(IP_INPUT_TIME) AS "time", IP_INPUT_VALUE AS "value" FROM "thetag"'
+        ),
+
+    }
+
+    assert expected[read_type] == res

--- a/tests/test_AspenHandlerODBC_connect.py
+++ b/tests/test_AspenHandlerODBC_connect.py
@@ -2,16 +2,14 @@ import pytest
 import os
 
 from tagreader.clients import IMSClient, list_sources
-from tagreader.odbc_handlers import (
-    list_aspen_sources,
-)
+from tagreader.odbc_handlers import list_aspen_sources
 
 is_GITHUBACTION = "GITHUB_ACTION" in os.environ
 
 if is_GITHUBACTION:
     pytest.skip(
         "All tests in module require connection to Aspen server",
-        allow_module_level=True
+        allow_module_level=True,
     )
 
 SOURCE = "SNA"

--- a/tests/test_AspenHandlerREST.py
+++ b/tests/test_AspenHandlerREST.py
@@ -87,7 +87,7 @@ def test_generate_map_query(AspenHandler):
         # pytest.param("BAD", 0, marks=pytest.mark.skip),
         # pytest.param("TOTAL", 0, marks=pytest.mark.skip),
         # pytest.param("SUM", 0, marks=pytest.mark.skip),
-        # pytest.param("SNAPSHOT", 0, marks=pytest.mark.skip),
+        "SNAPSHOT",
     ],
 )
 def test_generate_tag_read_query(AspenHandler, read_type):
@@ -163,6 +163,11 @@ def test_generate_tag_read_query(AspenHandler, read_type):
         "BAD": ("whatever"),
         "TOTAL": ("whatever"),
         "SUM": ("whatever"),
-        "SNAPSHOT": ("whatever"),
+        "SNAPSHOT": (
+            '<Q f="d" allQuotes="1" rt="1593014400000" uc="0">'
+            "<Tag><N><![CDATA[ATCAI]]></N>"
+            "<D><![CDATA[sourcename]]></D><F><![CDATA[VAL]]></F>"
+            "<VS>1</VS><S>0</S></Tag></Q>"
+            ),
     }
     assert expected[read_type] == res

--- a/tests/test_PIHandlerODBC.py
+++ b/tests/test_PIHandlerODBC.py
@@ -3,6 +3,10 @@ import pandas as pd
 from tagreader import utils
 from tagreader.utils import ReaderType
 
+START_TIME = "2018-01-17 16:00:00"
+STOP_TIME = "2018-01-17 17:00:00"
+SAMPLE_TIME = 60
+
 
 @pytest.fixture(scope="module")
 def PIHandler():
@@ -24,17 +28,89 @@ def test_generate_connection_string(PIHandler):
     assert expected == res
 
 
-def test_generate_tag_read_query(PIHandler):
-    start_time = utils.ensure_datetime_with_tz("2018-01-17 16:00:00")
-    stop_time = utils.ensure_datetime_with_tz("2018-01-17 17:00:00")
-    ts = pd.Timedelta(1, unit="m")
-    res = PIHandler.generate_read_query(
-        "thetag", start_time, stop_time, ts, ReaderType.INT
-    )
-    expected = (
-        "SELECT CAST(value as FLOAT32) AS value, time "
-        "FROM [piarchive]..[piinterp2] WHERE tag='thetag' "
-        "AND (time BETWEEN '17-Jan-18 15:00:00' AND '17-Jan-18 16:00:00') "
-        "AND (timestep = '60s') ORDER BY time"
-    )
-    assert expected == res
+@pytest.mark.parametrize(
+    "read_type",
+    [
+        # pytest.param("RAW", marks=pytest.mark.skip(reason="Not implemented")),
+        # pytest.param(
+        #     "SHAPEPRESERVING", marks=pytest.mark.skip(reason="Not implemented")
+        # ),
+        "INT",
+        "MIN",
+        "MAX",
+        "RNG",
+        "AVG",
+        "STD",
+        "VAR",
+        # pytest.param("COUNT", marks=pytest.mark.skip(reason="Not implemented")),
+        # pytest.param("GOOD", marks=pytest.mark.skip(reason="Not implemented")),
+        # pytest.param("BAD", marks=pytest.mark.skip(reason="Not implemented")),
+        # pytest.param("TOTAL", marks=pytest.mark.skip(reason="Not implemented")),
+        # pytest.param("SUM", marks=pytest.mark.skip(reason="Not implemented")),
+        "SNAPSHOT",
+    ],
+)
+def test_generate_tag_read_query(PIHandler, read_type):
+    starttime = utils.ensure_datetime_with_tz(START_TIME)
+    stoptime = utils.ensure_datetime_with_tz(STOP_TIME)
+    ts = pd.Timedelta(SAMPLE_TIME, unit="s")
+
+    if read_type == "SNAPSHOT":
+        res = PIHandler.generate_read_query(
+            "thetag", None, None, None, getattr(ReaderType, read_type)
+        )
+    else:
+        res = PIHandler.generate_read_query(
+            "thetag", starttime, stoptime, ts, getattr(ReaderType, read_type)
+        )
+
+        
+    expected = {
+        "INT": (
+            "SELECT CAST(value as FLOAT32) AS value, time "
+            "FROM [piarchive]..[piinterp2] WHERE tag='thetag' "
+            "AND (time BETWEEN '17-Jan-18 15:00:00' AND '17-Jan-18 16:00:00') "
+            "AND (timestep = '60s') ORDER BY time"
+        ),
+        "MIN": (
+            "SELECT CAST(value as FLOAT32) AS value, time "
+            "FROM [piarchive]..[pimin] WHERE tag='thetag' "
+            "AND (time BETWEEN '17-Jan-18 15:00:00' AND '17-Jan-18 16:00:00') "
+            "AND (timestep = '60s') ORDER BY time"
+        ),
+        "MAX": (
+            "SELECT CAST(value as FLOAT32) AS value, time "
+            "FROM [piarchive]..[pimax] WHERE tag='thetag' "
+            "AND (time BETWEEN '17-Jan-18 15:00:00' AND '17-Jan-18 16:00:00') "
+            "AND (timestep = '60s') ORDER BY time"
+        ),
+        "RNG": (
+            "SELECT CAST(value as FLOAT32) AS value, time "
+            "FROM [piarchive]..[pirange] WHERE tag='thetag' "
+            "AND (time BETWEEN '17-Jan-18 15:00:00' AND '17-Jan-18 16:00:00') "
+            "AND (timestep = '60s') ORDER BY time"
+        ),
+        "AVG": (
+            "SELECT CAST(value as FLOAT32) AS value, time "
+            "FROM [piarchive]..[piavg] WHERE tag='thetag' "
+            "AND (time BETWEEN '17-Jan-18 15:00:00' AND '17-Jan-18 16:00:00') "
+            "AND (timestep = '60s') ORDER BY time"
+        ),
+        "STD": (
+            "SELECT CAST(value as FLOAT32) AS value, time "
+            "FROM [piarchive]..[pistd] WHERE tag='thetag' "
+            "AND (time BETWEEN '17-Jan-18 15:00:00' AND '17-Jan-18 16:00:00') "
+            "AND (timestep = '60s') ORDER BY time"
+        ),
+        "VAR": (
+            "SELECT POWER(CAST(value as FLOAT32), 2) AS value, time "
+            "FROM [piarchive]..[pistd] WHERE tag='thetag' "
+            "AND (time BETWEEN '17-Jan-18 15:00:00' AND '17-Jan-18 16:00:00') "
+            "AND (timestep = '60s') ORDER BY time"
+        ),
+        "SNAPSHOT": (
+            "SELECT CAST(value as FLOAT32) AS value, time "
+            "FROM [piarchive]..[pisnapshot] WHERE tag='thetag'"
+        ),
+    }
+    assert expected[read_type] == res

--- a/tests/test_PIHandlerODBC_connect.py
+++ b/tests/test_PIHandlerODBC_connect.py
@@ -85,16 +85,22 @@ def test_search(Client):
         # pytest.param("BAD", 0, marks=pytest.mark.skip(reason="Not implemented")),
         # pytest.param("TOTAL", 0, marks=pytest.mark.skip(reason="Not implemented")),
         # pytest.param("SUM", 0, marks=pytest.mark.skip(reason="Not implemented")),
-        # pytest.param("SNAPSHOT", 0, marks=pytest.mark.skip(reason="Not implemented")),
+        ("SNAPSHOT", 1),
     ],
 )
 def test_read(Client, read_type, size):
-    df = Client.read(
-        tags["Float32"], interval[0], interval[1], 60, getattr(ReaderType, read_type)
-    )
+    if read_type == "SNAPSHOT":
+        df = Client.read(
+            tags["Float32"], read_type=getattr(ReaderType, read_type)
+        )
+    else:
+        df = Client.read(
+            tags["Float32"], interval[0], interval[1], 60, getattr(ReaderType, read_type)
+        )
     assert df.shape == (size, 1)
-    assert df.index[0] == ensure_datetime_with_tz(interval[0])
-    assert df.index[-1] == df.index[0] + (size - 1) * pd.Timedelta(60, unit="s")
+    if read_type != "SNAPSHOT":
+        assert df.index[0] == ensure_datetime_with_tz(interval[0])
+        assert df.index[-1] == df.index[0] + (size - 1) * pd.Timedelta(60, unit="s")
 
 
 def test_digitalread_is_one_or_zero(Client):

--- a/tests/test_PIHandlerREST.py
+++ b/tests/test_PIHandlerREST.py
@@ -72,7 +72,7 @@ def test_is_summary(PIHandler):
         # pytest.param("BAD", marks=pytest.mark.skip(reason="Not implemented")),
         # pytest.param("TOTAL", marks=pytest.mark.skip(reason="Not implemented")),
         # pytest.param("SUM", marks=pytest.mark.skip(reason="Not implemented")),
-        # pytest.param("SNAPSHOT", marks=pytest.mark.skip(reason="Not implemented")),
+        "SNAPSHOT",
     ],
 )
 def test_generate_read_query(PIHandler, read_type):  # TODO: Move away from test*connect
@@ -87,8 +87,9 @@ def test_generate_read_query(PIHandler, read_type):  # TODO: Move away from test
         ts,
         getattr(ReaderType, read_type),
     )
-    assert params["startTime"] == "01-Apr-20 09:05:00"
-    assert params["endTime"] == "01-Apr-20 10:05:00"
+    if read_type != "SNAPSHOT":
+        assert params["startTime"] == "01-Apr-20 09:05:00"
+        assert params["endTime"] == "01-Apr-20 10:05:00"
 
     if read_type == "INT":
         assert url == f"streams/{PIHandler.webidcache['alreadyknowntag']}/interpolated"
@@ -111,3 +112,10 @@ def test_generate_read_query(PIHandler, read_type):  # TODO: Move away from test
             "VAR": "StdDev",
         }.get(read_type) == params["summaryType"]
         assert params["summaryDuration"] == f"{SAMPLE_TIME}s"
+    elif read_type == "SNAPSHOT":
+        assert url == f"streams/{PIHandler.webidcache['alreadyknowntag']}/end"
+        assert (
+            params["selectedFields"] == "Timestamp;Value;Good"
+        )
+        assert len(params) == 1
+

--- a/tests/test_PIHandlerREST.py
+++ b/tests/test_PIHandlerREST.py
@@ -113,9 +113,9 @@ def test_generate_read_query(PIHandler, read_type):  # TODO: Move away from test
         }.get(read_type) == params["summaryType"]
         assert params["summaryDuration"] == f"{SAMPLE_TIME}s"
     elif read_type == "SNAPSHOT":
-        assert url == f"streams/{PIHandler.webidcache['alreadyknowntag']}/end"
+        assert url == f"streams/{PIHandler.webidcache['alreadyknowntag']}/value"
         assert (
             params["selectedFields"] == "Timestamp;Value;Good"
         )
-        assert len(params) == 1
+        assert len(params) == 3
 

--- a/tests/test_PIHandlerREST_connect.py
+++ b/tests/test_PIHandlerREST_connect.py
@@ -136,9 +136,10 @@ def test_read(Client, read_type, size):
         )
 
     assert df.shape == (size, 1)
-    assert df.index[-1] == df.index[0] + (size - 1) * pd.Timedelta(
-        SAMPLE_TIME, unit="s"
-    )
+    if read_type != "SNAPSHOT":
+        assert df.index[-1] == df.index[0] + (size - 1) * pd.Timedelta(
+            SAMPLE_TIME, unit="s"
+        )
 
 
 def test_read_only_invalid_data_yields_nan_for_invalid(Client):

--- a/tests/test_PIHandlerREST_connect.py
+++ b/tests/test_PIHandlerREST_connect.py
@@ -121,18 +121,18 @@ def test_tag_to_webid(PIHandler):
     ],
 )
 def test_read(Client, read_type, size):
-    if read_type == ReaderType.SNAPSHOT:
+    if read_type == "SNAPSHOT":
         df = Client.read(
             TAGS["Float32"],
-            getattr(ReaderType, read_type),
+            read_type=getattr(ReaderType, read_type),
         )
     else:
         df = Client.read(
             TAGS["Float32"],
-            START_TIME,
-            STOP_TIME,
-            SAMPLE_TIME,
-            getattr(ReaderType, read_type),
+            start_time=START_TIME,
+            end_time=STOP_TIME,
+            ts=SAMPLE_TIME,
+            read_type=getattr(ReaderType, read_type),
         )
 
     assert df.shape == (size, 1)

--- a/tests/test_PIHandlerREST_connect.py
+++ b/tests/test_PIHandlerREST_connect.py
@@ -1,6 +1,7 @@
 import pytest
 import os
 import pandas as pd
+from requests_kerberos.kerberos_ import SanitizedResponse
 from tagreader.utils import ReaderType
 from tagreader.web_handlers import (
     list_piwebapi_sources,
@@ -116,17 +117,24 @@ def test_tag_to_webid(PIHandler):
         # pytest.param("BAD", 0, marks=pytest.mark.skip(reason="Not implemented")),
         # pytest.param("TOTAL", 0, marks=pytest.mark.skip(reason="Not implemented")),
         # pytest.param("SUM", 0, marks=pytest.mark.skip(reason="Not implemented")),
-        # pytest.param("SNAPSHOT", 0, marks=pytest.mark.skip(reason="Not implemented")),
+        ("SNAPSHOT", 1),
     ],
 )
 def test_read(Client, read_type, size):
-    df = Client.read(
-        TAGS["Float32"],
-        START_TIME,
-        STOP_TIME,
-        SAMPLE_TIME,
-        getattr(ReaderType, read_type),
-    )
+    if read_type == ReaderType.SNAPSHOT:
+        df = Client.read(
+            TAGS["Float32"],
+            getattr(ReaderType, read_type),
+        )
+    else:
+        df = Client.read(
+            TAGS["Float32"],
+            START_TIME,
+            STOP_TIME,
+            SAMPLE_TIME,
+            getattr(ReaderType, read_type),
+        )
+
     assert df.shape == (size, 1)
     assert df.index[-1] == df.index[0] + (size - 1) * pd.Timedelta(
         SAMPLE_TIME, unit="s"


### PR DESCRIPTION
Support for calling read() with ReaderType.SNAPSHOT added to all handlers.

Renamed stop_time to end_time.
The read() input arguments start_time, stop_time and ts are now keyword arguments. ts is default 60 (seconds).
For Web based handlers, end_time is an optional argument to snapshot reads. Will fetch a snapshot from the time provided.
