### PR TITLE
Add support for reading raw data

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -232,6 +232,7 @@ By specifying the optional parameter `read_type` to `read()` , it is possible to
   + `VAR` : The variance.
   + `STD` : The standard deviation.
   + `RNG` : The range (max-min).
+* `RAW`: Returns actual data points stored in the database.
 * `SNAPSHOT` : Returns the last recorded value. Only one tag can be read at a time. When using either of the Web API based handlers, providing `end_time` is possible in which case a snapshot at the specific time is returned.
 
 **Examples**
@@ -266,6 +267,8 @@ c.connect()
 ```
 
 Snapshots (`read_type = ReaderType.SNAPSHOT`) are of course never cached.
+
+**Note**: Raw `read_type = ReaderType.RAW` data values are currently not cached pending a rewrite of the caching mechanisms.
 
 ## Time zones
 

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -71,7 +71,7 @@ from tagreader.utils import add_statoil_root_certificate
 add_statoil_root_certificate()
 ```
 
-The output should inform you that the certificate was successfully added. This only needs to be done once per virtual environment. The function should detect if the certificate has been added before to avoid duplication.
+The output should inform you that the certificate was successfully added. This needs to be repeated whenever certifi is upgraded in your python virtual environment. It is safe to run more than once: If the function detects that the certificate has already been added to your current certifi installation, the certificate will not be duplicated.
 
 ### For non-Equinor users
 
@@ -264,6 +264,8 @@ c = tagreader.IMSClient("PINO", "pi")
 c.cache = None
 c.connect()
 ```
+
+Snapshots (`read_type = ReaderType.SNAPSHOT`) are of course never cached.
 
 ## Time zones
 

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,13 @@ pip install --upgrade tagreader
 ```
 import tagreader
 c = tagreader.IMSClient("mysource", "ip21")
-print(c.search("mytag%"))
-df = s.read_tags(["mytag_1", "mytag_2;with map"], "18.06.2020 08:00:00", "18.06.2020 09:00:00", 60)
+print(c.search("tag*"))
+df = s.read_tags(["tag1", "tag2"], "18.06.2020 08:00:00", "18.06.2020 09:00:00", 60)
 ```
 
-Also see the [quickstart](https://github.com/equinor/tagreader-python/blob/master/docs/quickstart.ipynb) document at gitlab.
+Also see the
+[quickstart](https://github.com/equinor/tagreader-python/blob/master/docs/quickstart.ipynb)
+document at gitlab.
 """
 
 setup(

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -376,8 +376,8 @@ class IMSClient:
         which can be imported as follows:
             from utils import ReaderType
 
-        Values for ReaderType.* that should work are:
-            INT, MIN, MAX, RNG, AVG, VAR, STD and SNAPSHOT
+        Values for ReaderType.* that should work for all handlers are:
+            INT, RAW, MIN, MAX, RNG, AVG, VAR, STD and SNAPSHOT
         """
         if isinstance(tags, str):
             tags = [tags]

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -285,7 +285,10 @@ class IMSClient:
                         tag, start, stop, ts, read_type, metadata
                     )
                     if len(df.index) > 0:
-                        if cache is not None and read_type not in [ReaderType.SNAPSHOT, ReaderType.RAW]:
+                        if cache is not None and read_type not in [
+                            ReaderType.SNAPSHOT,
+                            ReaderType.RAW,
+                        ]:
                             cache.store(df, read_type, ts)
                         frames.append(df)
                     if len(df) < self.handler._max_rows:
@@ -327,7 +330,7 @@ class IMSClient:
                     units[tag] = r["unit"]
             if tag not in units:
                 unit = self.handler._get_tag_unit(tag)
-                if self.cache is not None and desc is not None:
+                if self.cache is not None and unit is not None:
                     self.cache.store_tag_metadata(tag, {"unit": unit})
                 units[tag] = unit
         return units

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -263,7 +263,7 @@ class IMSClient:
         else:
             missing_intervals = [(start_time, stop_time)]
             df = pd.DataFrame()
-            if cache is not None:
+            if cache is not None and read_type != ReaderType.RAW:
                 time_slice = get_next_timeslice(start_time, stop_time, ts)
                 df = cache.fetch(
                     tag,
@@ -288,7 +288,7 @@ class IMSClient:
                     df = self.handler.read_tag(
                         tag, time_slice[0], time_slice[1], ts, read_type, metadata
                     )
-                    if cache is not None:
+                    if cache is not None and read_type != ReaderType.RAW:
                         cache.store(df, read_type, ts)
                     frames.append(df)
             # df = pd.concat(frames, verify_integrity=True)
@@ -364,7 +364,7 @@ class IMSClient:
         which can be imported as follows:
             from utils import ReaderType
 
-        Values for Readertype.* that should work are:
+        Values for ReaderType.* that should work are:
             INT, MIN, MAX, RNG, AVG, VAR, STD and SNAPSHOT
         """
         if isinstance(tags, str):

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -289,16 +289,18 @@ class IMSClient:
                         df = self.handler.read_tag(
                             tag, time_slice[0], time_slice[1], ts, read_type, metadata
                         )
-                        if cache is not None and read_type != ReaderType.RAW:
-                            cache.store(df, read_type, ts)
-                        frames.append(df)
+                        if len(df.index) > 0:
+                            if cache is not None and read_type != ReaderType.RAW:
+                                cache.store(df, read_type, ts)
+                            frames.append(df)
                 else:
                     time_slice = [start, stop]
                     while True:
                         df = self.handler.read_tag(
                             tag, time_slice[0], time_slice[1], ts, read_type, metadata
                         )
-                        frames.append(df)
+                        if not df.empty:
+                            frames.append(df)
                         if len(df) < self.handler._max_rows:
                             break
                         time_slice[0] = df.index[-1]

--- a/tagreader/odbc_handlers.py
+++ b/tagreader/odbc_handlers.py
@@ -375,9 +375,8 @@ class PIHandlerODBC:
             )
         return " ".join(query)
 
-    @staticmethod
     def generate_read_query(
-        tag, start_time, stop_time, sample_time, read_type, metadata=None
+        self, tag, start_time, stop_time, sample_time, read_type, metadata=None
     ):
         if read_type in [
             ReaderType.COUNT,
@@ -385,7 +384,6 @@ class PIHandlerODBC:
             ReaderType.BAD,
             ReaderType.TOTAL,
             ReaderType.SUM,
-            ReaderType.RAW,
             ReaderType.SHAPEPRESERVING,
         ]:
             raise NotImplementedError
@@ -433,6 +431,8 @@ class PIHandlerODBC:
             query = ["SELECT CAST(pctgood as FLOAT32)"]
         elif ReaderType.BAD == read_type:
             query = ["SELECT 100-CAST(pctgood as FLOAT32)"]
+        elif ReaderType.RAW == read_type:
+            query = [f"SELECT TOP {self._max_rows} CAST(value as FLOAT32)"]
         else:
             query = ["SELECT CAST(value as FLOAT32)"]
 
@@ -458,7 +458,7 @@ class PIHandlerODBC:
             )
         elif ReaderType.RAW == read_type:
             pass
-        elif ReaderType.SNAPSHOT != read_type:
+        elif read_type not in [ReaderType.SNAPSHOT, ReaderType.RAW]:
             query.extend([f"AND (timestep = '{sample_time}s')"])
 
         if ReaderType.SNAPSHOT != read_type:

--- a/tagreader/odbc_handlers.py
+++ b/tagreader/odbc_handlers.py
@@ -79,7 +79,6 @@ class AspenHandlerODBC:
             ReaderType.BAD,
             ReaderType.TOTAL,
             ReaderType.SUM,
-            ReaderType.RAW,
             ReaderType.SHAPEPRESERVING,
         ]:
             raise (NotImplementedError)
@@ -156,11 +155,13 @@ class AspenHandlerODBC:
             query.extend([f"WHERE name = {tag!r}"])
             if mapdef:
                 query.extend([f'AND FIELD_ID = FT({mapdef["MAP_HistoryValue"]!r})'])
+            if ReaderType.RAW != read_type:
+                query.extend([f"AND (period = {sample_time*10})"])
             query.extend(
                 [
+                    f"AND (request = {request_num})",
                     f"AND (ts BETWEEN {start!r} AND {stop!r})",
-                    f"AND (request = {request_num}) AND (period = {sample_time*10})",
-                    "ORDER BY ts",
+                    "ORDER BY ts"
                 ]
             )
 

--- a/tagreader/web_handlers.py
+++ b/tagreader/web_handlers.py
@@ -75,7 +75,7 @@ class AspenHandlerWeb:
     def __init__(
         self, datasource=None, url=None, auth=None, verifySSL=None, options={},
     ):
-        self._max_rows = options.get("max_rows", 100000)
+        self._max_rows = options.get("max_rows", 10000)
         if url is None:
             url = r"https://ws2679.statoil.net/ProcessData/AtProcessDataREST.dll"
         self.base_url = url
@@ -430,7 +430,7 @@ class PIHandlerWeb:
     def __init__(
         self, url=None, datasource=None, auth=None, verifySSL=None, options={},
     ):
-        self._max_rows = options.get("max_rows", 100000)
+        self._max_rows = options.get("max_rows", 10000)
         if url is None:
             url = r"https://piwebapi.equinor.com/piwebapi"
         self.base_url = url
@@ -552,6 +552,9 @@ class PIHandlerWeb:
             params["selectedFields"] = "Links;Items.Timestamp;Items.Value;Items.Good"
         elif read_type == ReaderType.SNAPSHOT:
             params["selectedFields"] = "Timestamp;Value;Good"
+
+        if read_type == ReaderType.RAW:
+            params["maxCount"] = self._max_rows
 
         return (url, params)
 

--- a/tagreader/web_handlers.py
+++ b/tagreader/web_handlers.py
@@ -148,7 +148,7 @@ class AspenHandlerWeb:
         if read_type == ReaderType.SNAPSHOT:
             if stop_time is not None:
                 use_current = 0
-                end_time = int(stop_time.timestamp())*1000
+                end_time = int(stop_time.timestamp()) * 1000
             else:
                 use_current = 1
                 end_time = 0
@@ -162,15 +162,10 @@ class AspenHandlerWeb:
         if mapname:
             query += f"<M><![CDATA[{mapname}]]></M>"
 
-        query += (
-            f"<D><![CDATA[{self.datasource}]]></D>"
-            "<F><![CDATA[VAL]]></F>"
-        )
+        query += f"<D><![CDATA[{self.datasource}]]></D>" "<F><![CDATA[VAL]]></F>"
 
         if read_type == ReaderType.SNAPSHOT:
-            query += (
-                "<VS>1</VS>"
-            )
+            query += "<VS>1</VS>"
         else:
             query += (
                 "<HF>0</HF>"  # History format: 0=Raw, 1=RecordAsString
@@ -184,7 +179,11 @@ class AspenHandlerWeb:
             query += f"<O>{outsiders}</O>"
         if read_type not in [ReaderType.RAW]:
             query += f"<S>{stepped}</S>"
-        if read_type not in [ReaderType.RAW, ReaderType.SHAPEPRESERVING, ReaderType.SNAPSHOT]:
+        if read_type not in [
+            ReaderType.RAW,
+            ReaderType.SHAPEPRESERVING,
+            ReaderType.SNAPSHOT,
+        ]:
             query += (
                 f"<P>{int(sample_time.total_seconds())}</P>"
                 "<PU>3</PU>"  # Period Unit: 0=day, 1=hour, 2=min, 3=sec
@@ -193,7 +192,7 @@ class AspenHandlerWeb:
             ReaderType.RAW,
             ReaderType.SHAPEPRESERVING,
             ReaderType.INT,
-            ReaderType.SNAPSHOT
+            ReaderType.SNAPSHOT,
         ]:
             query += (
                 # Method: 0=integral, 2=value, 3=integral complete, 4=value complete
@@ -394,7 +393,8 @@ class AspenHandlerWeb:
             ReaderType.AVG,
             ReaderType.VAR,
             ReaderType.STD,
-            ReaderType.SNAPSHOT
+            ReaderType.SNAPSHOT,
+            ReaderType.RAW,
         ]:
             raise (NotImplementedError)
 
@@ -527,9 +527,7 @@ class PIHandlerWeb:
             )
             params["timeZone"] = "UTC"
         elif read_type == ReaderType.SNAPSHOT and stop_time is not None:
-            params["time"] = stop_time.tz_convert("UTC").strftime(
-                timecast_format_query
-            )
+            params["time"] = stop_time.tz_convert("UTC").strftime(timecast_format_query)
             params["timeZone"] = "UTC"
 
         summary_type = {

--- a/tagreader/web_handlers.py
+++ b/tagreader/web_handlers.py
@@ -613,6 +613,8 @@ class PIHandlerWeb:
 
     def _get_tag_unit(self, tag):
         webid = self.tag_to_webid(tag)
+        if webid is None:
+            return None
         url = urljoin(self.base_url, "points", webid)
         res = self.session.get(url)
         if res.status_code != 200:
@@ -623,6 +625,8 @@ class PIHandlerWeb:
 
     def _get_tag_description(self, tag):
         webid = self.tag_to_webid(tag)
+        if webid is None:
+            return None
         url = urljoin(self.base_url, "points", webid)
         res = self.session.get(url)
         if res.status_code != 200:
@@ -662,7 +666,7 @@ class PIHandlerWeb:
                             f"Received {len(j['Items'])} results when trying to find unique WebId for {tag}."  # noqa: E501
                         )
             elif len(j["Items"]) == 0:
-                warnings.warn(f"Tag {tag} not found", RuntimeWarning)
+                warnings.warn(f"Tag {tag} not found")
                 return None
 
             webid = j["Items"][0]["WebId"]

--- a/tests/test_AspenHandlerODBC.py
+++ b/tests/test_AspenHandlerODBC.py
@@ -21,7 +21,7 @@ def test_generate_connection_string():
 @pytest.mark.parametrize(
     "read_type",
     [
-        # pytest.param("RAW", marks=pytest.mark.skip(reason="Not implemented")),
+        "RAW",
         # pytest.param(
         #     "SHAPEPRESERVING", marks=pytest.mark.skip(reason="Not implemented")
         # ),
@@ -55,40 +55,53 @@ def test_generate_tag_read_query(read_type):
         )
 
     expected = {
+        "RAW": (
+            'SELECT ISO8601(ts) AS "time", value AS "value" FROM history WHERE '
+            "name = 'thetag' AND (request = 4) "
+            "AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "ORDER BY ts"
+        ),
         "INT": (
             'SELECT ISO8601(ts) AS "time", value AS "value" FROM history WHERE '
-            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
-            "'2018-01-17T16:00:00Z') AND (request = 7) AND (period = 600) ORDER BY ts"
+            "name = 'thetag' AND (period = 600) AND (request = 7) "
+            "AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "ORDER BY ts"
         ),
         "MIN": (
             'SELECT ISO8601(ts_start) AS "time", min AS "value" FROM aggregates WHERE '
-            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
-            "'2018-01-17T16:00:00Z') AND (request = 1) AND (period = 600) ORDER BY ts"
+            "name = 'thetag' AND (period = 600) AND (request = 1) "
+            "AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "ORDER BY ts"
         ),
         "MAX": (
             'SELECT ISO8601(ts_start) AS "time", max AS "value" FROM aggregates WHERE '
-            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
-            "'2018-01-17T16:00:00Z') AND (request = 1) AND (period = 600) ORDER BY ts"
+            "name = 'thetag' AND (period = 600) AND (request = 1) "
+            "AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "ORDER BY ts"
         ),
         "RNG": (
             'SELECT ISO8601(ts_start) AS "time", rng AS "value" FROM aggregates WHERE '
-            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
-            "'2018-01-17T16:00:00Z') AND (request = 1) AND (period = 600) ORDER BY ts"
+            "name = 'thetag' AND (period = 600) AND (request = 1) "
+            "AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "ORDER BY ts"
         ),
         "AVG": (
             'SELECT ISO8601(ts_start) AS "time", avg AS "value" FROM aggregates WHERE '
-            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
-            "'2018-01-17T16:00:00Z') AND (request = 1) AND (period = 600) ORDER BY ts"
+            "name = 'thetag' AND (period = 600) AND (request = 1) "
+            "AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "ORDER BY ts"
         ),
         "STD": (
             'SELECT ISO8601(ts_start) AS "time", std AS "value" FROM aggregates WHERE '
-            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
-            "'2018-01-17T16:00:00Z') AND (request = 1) AND (period = 600) ORDER BY ts"
+            "name = 'thetag' AND (period = 600) AND (request = 1) "
+            "AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "ORDER BY ts"
         ),
         "VAR": (
             'SELECT ISO8601(ts_start) AS "time", var AS "value" FROM aggregates WHERE '
-            "name = 'thetag' AND (ts BETWEEN '2018-01-17T15:00:00Z' AND "
-            "'2018-01-17T16:00:00Z') AND (request = 1) AND (period = 600) ORDER BY ts"
+            "name = 'thetag' AND (period = 600) AND (request = 1) "
+            "AND (ts BETWEEN '2018-01-17T15:00:00Z' AND '2018-01-17T16:00:00Z') "
+            "ORDER BY ts"
         ),
         "SNAPSHOT": (
             'SELECT ISO8601(IP_INPUT_TIME) AS "time", IP_INPUT_VALUE AS "value" '

--- a/tests/test_AspenHandlerODBC_connect.py
+++ b/tests/test_AspenHandlerODBC_connect.py
@@ -14,6 +14,8 @@ if is_GITHUBACTION:
 
 SOURCE = "SNA"
 TAGS = ["ATCAI", "ATCMIXTIME1"]
+START_TIME = "2018-05-01 10:00:00"
+STOP_TIME = "2018-05-01 11:00:00"
 
 
 @pytest.fixture()
@@ -42,3 +44,14 @@ def test_list_sources_aspen():
     assert isinstance(res[0], str)
     for r in res:
         assert 3 <= len(r) <= 20
+
+
+def test_handle_unknown_tag(Client):
+    with pytest.warns(None):
+        df = Client.read(["sorandomitcantexist"], START_TIME, STOP_TIME)
+    assert len(df.index) == 0
+    with pytest.warns(None):
+        df = Client.read(["ATCAI", "sorandomitcantexist"], START_TIME, STOP_TIME)
+    assert len(df.index) > 0
+    assert len(df.columns == 1)
+

--- a/tests/test_AspenHandlerODBC_connect.py
+++ b/tests/test_AspenHandlerODBC_connect.py
@@ -46,12 +46,11 @@ def test_list_sources_aspen():
         assert 3 <= len(r) <= 20
 
 
-def test_handle_unknown_tag(Client):
-    with pytest.warns(None):
+def test_read_unknown_tag(Client):
+    with pytest.warns(UserWarning):
         df = Client.read(["sorandomitcantexist"], START_TIME, STOP_TIME)
     assert len(df.index) == 0
-    with pytest.warns(None):
+    with pytest.warns(UserWarning):
         df = Client.read(["ATCAI", "sorandomitcantexist"], START_TIME, STOP_TIME)
     assert len(df.index) > 0
     assert len(df.columns == 1)
-

--- a/tests/test_PIHandlerODBC.py
+++ b/tests/test_PIHandlerODBC.py
@@ -31,7 +31,7 @@ def test_generate_connection_string(PIHandler):
 @pytest.mark.parametrize(
     "read_type",
     [
-        # pytest.param("RAW", marks=pytest.mark.skip(reason="Not implemented")),
+        "RAW",
         # pytest.param(
         #     "SHAPEPRESERVING", marks=pytest.mark.skip(reason="Not implemented")
         # ),
@@ -64,8 +64,13 @@ def test_generate_tag_read_query(PIHandler, read_type):
             "thetag", starttime, stoptime, ts, getattr(ReaderType, read_type)
         )
 
-        
     expected = {
+        "RAW": (
+            "SELECT TOP 100000 CAST(value as FLOAT32) AS value, time "
+            "FROM [piarchive]..[picomp2] WHERE tag='thetag' "
+            "AND (time BETWEEN '17-Jan-18 15:00:00' AND '17-Jan-18 16:00:00') "
+            "ORDER BY time"
+        ),
         "INT": (
             "SELECT CAST(value as FLOAT32) AS value, time "
             "FROM [piarchive]..[piinterp2] WHERE tag='thetag' "

--- a/tests/test_PIHandlerODBC_connect.py
+++ b/tests/test_PIHandlerODBC_connect.py
@@ -170,6 +170,8 @@ def test_read_unknown_tag(Client):
         df = Client.read(["sorandomitcantexist"], START_TIME, STOP_TIME)
     assert len(df.index) == 0
     with pytest.warns(UserWarning):
-        df = Client.read([TAGS['Float32'], "sorandomitcantexist"], START_TIME, STOP_TIME)
+        df = Client.read(
+            [TAGS["Float32"], "sorandomitcantexist"], START_TIME, STOP_TIME
+        )
     assert len(df.index) > 0
     assert len(df.columns == 1)

--- a/tests/test_PIHandlerODBC_connect.py
+++ b/tests/test_PIHandlerODBC_connect.py
@@ -165,11 +165,11 @@ def test_to_DST_skips_time(Client):
     )
 
 
-def test_handle_unknown_tag(Client):
-    with pytest.warns(None):
+def test_read_unknown_tag(Client):
+    with pytest.warns(UserWarning):
         df = Client.read(["sorandomitcantexist"], START_TIME, STOP_TIME)
     assert len(df.index) == 0
-    with pytest.warns(None):
+    with pytest.warns(UserWarning):
         df = Client.read([TAGS['Float32'], "sorandomitcantexist"], START_TIME, STOP_TIME)
     assert len(df.index) > 0
     assert len(df.columns == 1)

--- a/tests/test_PIHandlerREST.py
+++ b/tests/test_PIHandlerREST.py
@@ -124,3 +124,4 @@ def test_generate_read_query(PIHandler, read_type):  # TODO: Move away from test
         assert (
             params["selectedFields"] == "Links;Items.Timestamp;Items.Value;Items.Good"
         )
+        assert params["maxCount"] == 10000

--- a/tests/test_PIHandlerREST.py
+++ b/tests/test_PIHandlerREST.py
@@ -56,7 +56,7 @@ def test_is_summary(PIHandler):
 @pytest.mark.parametrize(
     "read_type",
     [
-        # pytest.param("RAW", marks=pytest.mark.skip(reason="Not implemented")),
+        "RAW",
         # pytest.param(
         #     "SHAPEPRESERVING", marks=pytest.mark.skip(reason="Not implemented")
         # ),
@@ -90,6 +90,7 @@ def test_generate_read_query(PIHandler, read_type):  # TODO: Move away from test
     if read_type != "SNAPSHOT":
         assert params["startTime"] == "01-Apr-20 09:05:00"
         assert params["endTime"] == "01-Apr-20 10:05:00"
+        assert params["timeZone"] == "UTC"
 
     if read_type == "INT":
         assert url == f"streams/{PIHandler.webidcache['alreadyknowntag']}/interpolated"
@@ -118,4 +119,8 @@ def test_generate_read_query(PIHandler, read_type):  # TODO: Move away from test
             params["selectedFields"] == "Timestamp;Value;Good"
         )
         assert len(params) == 3
-
+    elif read_type == "RAW":
+        assert url == f"streams/{PIHandler.webidcache['alreadyknowntag']}/recorded"
+        assert (
+            params["selectedFields"] == "Links;Items.Timestamp;Items.Value;Items.Good"
+        )

--- a/tests/test_PIHandlerREST_connect.py
+++ b/tests/test_PIHandlerREST_connect.py
@@ -125,10 +125,7 @@ def test_tag_to_webid(PIHandler):
 )
 def test_read(Client, read_type, size):
     if read_type == "SNAPSHOT":
-        df = Client.read(
-            TAGS["Float32"],
-            read_type=getattr(ReaderType, read_type),
-        )
+        df = Client.read(TAGS["Float32"], read_type=getattr(ReaderType, read_type),)
     else:
         df = Client.read(
             TAGS["Float32"],
@@ -154,7 +151,8 @@ def test_read_raw_long(Client):
         TAGS["Float32"],
         start_time=START_TIME,
         end_time="2020-04-11 20:00:00",
-        read_type=ReaderType.RAW)
+        read_type=ReaderType.RAW,
+    )
     assert len(df) > 1000
 
 
@@ -229,6 +227,8 @@ def test_read_unknown_tag(Client):
         df = Client.read(["sorandomitcantexist"], START_TIME, STOP_TIME)
     assert len(df.index) == 0
     with pytest.warns(UserWarning):
-        df = Client.read([TAGS['Float32'], "sorandomitcantexist"], START_TIME, STOP_TIME)
+        df = Client.read(
+            [TAGS["Float32"], "sorandomitcantexist"], START_TIME, STOP_TIME
+        )
     assert len(df.index) > 0
     assert len(df.columns == 1)

--- a/tests/test_PIHandlerREST_connect.py
+++ b/tests/test_PIHandlerREST_connect.py
@@ -97,7 +97,7 @@ def test_tag_to_webid(PIHandler):
     assert len(res) >= 20
     with pytest.raises(AssertionError):
         res = PIHandler.tag_to_webid("SINUSOID*")
-    with pytest.raises(AssertionError):
+    with pytest.warns(None):
         res = PIHandler.tag_to_webid("somerandomgarbage")
 
 
@@ -224,11 +224,11 @@ def test_to_DST_skips_time(Client):
     )
 
 
-def test_handle_unknown_tag(Client):
-    with pytest.warns(None):
+def test_read_unknown_tag(Client):
+    with pytest.warns(UserWarning):
         df = Client.read(["sorandomitcantexist"], START_TIME, STOP_TIME)
     assert len(df.index) == 0
-    with pytest.warns(None):
+    with pytest.warns(UserWarning):
         df = Client.read([TAGS['Float32'], "sorandomitcantexist"], START_TIME, STOP_TIME)
     assert len(df.index) > 0
     assert len(df.columns == 1)

--- a/tests/test_PIHandlerREST_connect.py
+++ b/tests/test_PIHandlerREST_connect.py
@@ -222,3 +222,13 @@ def test_to_DST_skips_time(Client):
     assert (
         df.loc["2018-03-25 01:50:00":"2018-03-25 03:10:00"].size == (2 + 1 * 6 + 1) - 6
     )
+
+
+def test_handle_unknown_tag(Client):
+    with pytest.warns(None):
+        df = Client.read(["sorandomitcantexist"], START_TIME, STOP_TIME)
+    assert len(df.index) == 0
+    with pytest.warns(None):
+        df = Client.read([TAGS['Float32'], "sorandomitcantexist"], START_TIME, STOP_TIME)
+    assert len(df.index) > 0
+    assert len(df.columns == 1)


### PR DESCRIPTION
Added support for ReaderType.RAW for all handlers.

Rewrote tag reading mechanism by moving responsibility for limiting amount of data points returned from client to handler. Client now investigates length of returned result to determine start time of next query, instead of querying predetermined fixed-length intervals. This makes a more unified read algorithm for fixed-length intervals (such as INT) and uneven time series (such as RAW).

Reduced max rows per query from PI Web API to default value 10000.

Warn instead of crash when user tries to read an invalid tag.