### PR TITLE
Add host port arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,7 +139,7 @@ extratests
 extratests/*
 
 # tagreader cache file
-.h5
+*.h5
 
 # vscode
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+This changelog is deprecated. All changes are documented under [releases](https://github.com/equinor/tagreader-python/releases).
+
 ## [1.1.0] - 2020-06-18
 Improved handling of tags with maps for Aspen IP.21.
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,13 +38,24 @@ steps:
 
 - script: |
     coverage erase
+    del /f coverage.xml
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
+  condition: and(succeeded(), eq(variables['python.version'], '3.6'))
+  displayName: 'Run tests with coverage'
+  env: 
+    HTTPS_PROXY: $(var_http_proxy)
+
+- script: |
+    echo $(python.version)
+    pytest tests extratests
+  condition: and(succeeded(), not(eq(variables['python.version'], '3.6')))
   displayName: 'Run tests'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - task: PublishCodeCoverageResults@1
+  condition: and(succeeded(), eq(variables['python.version'], '3.6'))
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -159,6 +159,12 @@ The following input arguments can be used when connecting to either `piwebapi` o
 * `verifySSL` (optional): Whether to verify SSL certificate sent from server. **Default**: True.
 * `auth` (optional): Auth object to pass to the server for authentication. **Default**: Kerberos-based auth object that works with Equinor servers. If not connecting to an Equinor server, you need to create your own auth object.
 
+
+If `imstype` is an ODBC type, i.e. `pi` or `ip21`, the host and port to connect to will by default be found by performing a search in Windows registry. For some systems this may not work. In those cases the user can explicitly specify the following optional parameters:
+
+* `host` (optional): Overrides mapping of datasource to hostname via Windows registry.
+* `port` (optional): Overrides mapping of datasource to port number via Windows registry. **Default**: 10014 for `ip21` and 5450 for `pi`.
+
 ## Connecting to data source
 
 After creating the client as described above, connect to the server with the `connect()` method.
@@ -245,14 +251,14 @@ Read interpolated data for the provided tag with 3-minute intervals between the 
 ``` python
 c = tagreader.IMSClient("PINO", "pi")
 c.connect()
-df = c.read(['BA: ACTIVE.1'], '05-Jan-2020 08:00:00', '05/01/20 11:30am', 180)
+df = c.read(['BA:ACTIVE.1'], '05-Jan-2020 08:00:00', '05/01/20 11:30am', 180)
 
 ```
 
 Read the average value for the two provided tags within each 3-minute interval between the two time stamps:
 
 ``` python
-df = c.read(['BA: CONC.1'], '05-Jan-2020 08:00:00', '05/01/20 11:30am', 180, read_type=tagreader.ReaderType.AVG)
+df = c.read(['BA:CONC.1'], '05-Jan-2020 08:00:00', '05/01/20 11:30am', 180, read_type=tagreader.ReaderType.AVG)
 ```
 
 ## Caching results

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -162,7 +162,16 @@ def get_server_address_pi(datasource):
         return None
 
 
-def get_handler(imstype, datasource, url=None, options={}, verifySSL=None, auth=None):
+def get_handler(
+    imstype,
+    datasource,
+    url=None,
+    host=None,
+    port=None,
+    options={},
+    verifySSL=None,
+    auth=None,
+):
     accepted_values = ["pi", "aspen", "ip21", "piwebapi", "aspenone"]
 
     if not imstype or imstype.lower() not in accepted_values:
@@ -174,13 +183,16 @@ def get_handler(imstype, datasource, url=None, options={}, verifySSL=None, auth=
                 "No PI ODBC driver detected. "
                 "Either switch to Web API ('piweb') or install appropriate driver."
             )
-        hostport = get_server_address_pi(datasource)
-        if not hostport:
-            raise ValueError(
-                f"Unable to locate data source '{datasource}'."
-                "Do you have correct permissions?"
-            )
-        host, port = hostport
+        if host is None:
+            hostport = get_server_address_pi(datasource)
+            if not hostport:
+                raise ValueError(
+                    f"Unable to locate data source '{datasource}'."
+                    "Do you have correct permissions?"
+                )
+            host, port = hostport
+        if port is None:
+            port = 5450
         return PIHandlerODBC(host=host, port=port, options=options)
 
     if imstype.lower() in ["aspen", "ip21"]:
@@ -189,13 +201,16 @@ def get_handler(imstype, datasource, url=None, options={}, verifySSL=None, auth=
                 "No Aspen SQLplus ODBC driver detected. Either switch to Web API "
                 "('aspenweb') or install appropriate driver."
             )
-        hostport = get_server_address_aspen(datasource)
-        if not hostport:
-            raise ValueError(
-                f"Unable to locate data source '{datasource}'."
-                "Do you have correct permissions?"
-            )
-        host, port = hostport
+        if host is None:
+            hostport = get_server_address_aspen(datasource)
+            if not hostport:
+                raise ValueError(
+                    f"Unable to locate data source '{datasource}'."
+                    "Do you have correct permissions?"
+                )
+            host, port = hostport
+        if port is None:
+            port = 10014
         return AspenHandlerODBC(host=host, port=port, options=options)
 
     if imstype.lower() == "piwebapi":
@@ -224,6 +239,8 @@ class IMSClient:
         imstype=None,
         tz="Europe/Oslo",
         url=None,
+        host=None,
+        port=None,
         handler_options={},
         verifySSL=None,
         auth=None,
@@ -235,6 +252,8 @@ class IMSClient:
             imstype,
             datasource,
             url=url,
+            host=host,
+            port=port,
             options=handler_options,
             verifySSL=verifySSL,
             auth=auth,

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -172,10 +172,10 @@ def get_handler(
     verifySSL=None,
     auth=None,
 ):
-    accepted_values = ["pi", "aspen", "ip21", "piwebapi", "aspenone"]
+    accepted_imstypes = ["pi", "aspen", "ip21", "piwebapi", "aspenone"]
 
-    if not imstype or imstype.lower() not in accepted_values:
-        raise ValueError(f"`imstype` must be one of {accepted_values}")
+    if not imstype or imstype.lower() not in accepted_imstypes:
+        raise ValueError(f"`imstype` must be one of {accepted_imstypes}")
 
     if imstype.lower() == "pi":
         if "PI ODBC Driver" not in pyodbc.drivers():

--- a/tests/test_AspenHandlerODBC.py
+++ b/tests/test_AspenHandlerODBC.py
@@ -9,8 +9,17 @@ STOP_TIME = "2018-01-17 17:00:00"
 SAMPLE_TIME = 60
 
 
-def test_generate_connection_string():
-    res = AspenHandlerODBC.generate_connection_string("thehostname", 1234, 567890)
+@pytest.fixture(scope="module")
+def AspenHandler():
+    from tagreader.odbc_handlers import AspenHandlerODBC
+
+    yield AspenHandlerODBC(
+        "thehostname", 1234, options={"max_rows": 567890}
+    )
+
+
+def test_generate_connection_string(AspenHandler):
+    res = AspenHandler.generate_connection_string()
     expected = (
         "DRIVER={AspenTech SQLPlus};HOST=thehostname;PORT=1234;"
         "READONLY=Y;MAXROWS=567890"

--- a/tests/test_PIHandlerODBC.py
+++ b/tests/test_PIHandlerODBC.py
@@ -12,15 +12,15 @@ SAMPLE_TIME = 60
 def PIHandler():
     from tagreader.odbc_handlers import PIHandlerODBC
 
-    yield PIHandlerODBC("thehostname.statoil.net", 1234)
+    yield PIHandlerODBC(
+        "thehostname.statoil.net", 1234, options={"das_server": "the_das_server"}
+    )
 
 
 def test_generate_connection_string(PIHandler):
-    res = PIHandler.generate_connection_string(
-        PIHandler.host, PIHandler.port, "das_server"
-    )
+    res = PIHandler.generate_connection_string()
     expected = (
-        "DRIVER={PI ODBC Driver};Server=das_server;Trusted_Connection=Yes;"
+        "DRIVER={PI ODBC Driver};Server=the_das_server;Trusted_Connection=Yes;"
         "Command Timeout=1800;Provider Type=PIOLEDB;"
         "Provider String={Data source=thehostname;Integrated_Security=SSPI;"
         "Time Zone=UTC};"

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -52,26 +52,48 @@ def test_get_missing_intervals():
     )
 
 
-def test_init_PI_odbc_client_with_host_port():
-    host = 'thehostname'
+def test_PI_init_odbc_client_with_host_port():
+    host = "thehostname"
     port = 999
-    c = IMSClient(datasource='whatever', imstype='pi', host=host)
+    c = IMSClient(datasource="whatever", imstype="pi", host=host)
     assert c.handler.host == host
     assert c.handler.port == 5450
-    c = IMSClient(datasource='whatever', imstype='pi', host=host, port=port)
+    c = IMSClient(datasource="whatever", imstype="pi", host=host, port=port)
     assert c.handler.host == host
     assert c.handler.port == port
 
 
-def test_init_IP21_odbc_client_with_host_port():
-    host = 'thehostname'
+def test_IP21_init_odbc_client_with_host_port():
+    host = "thehostname"
     port = 999
-    c = IMSClient(datasource='whatever', imstype='ip21', host=host)
+    c = IMSClient(datasource="whatever", imstype="ip21", host=host)
     assert c.handler.host == host
     assert c.handler.port == 10014
-    c = IMSClient(datasource='whatever', imstype='ip21', host=host, port=port)
+    c = IMSClient(datasource="whatever", imstype="ip21", host=host, port=port)
     assert c.handler.host == host
     assert c.handler.port == port
+
+
+def test_PI_connection_string_override():
+    connstr = "someuserspecifiedconnectionstring"
+    c = IMSClient(
+        datasource="whatever",
+        host="host",
+        imstype="pi",
+        handler_options={"connection_string": connstr},
+    )
+    assert c.handler.generate_connection_string() == connstr
+
+
+def test_IP21_connection_string_override():
+    connstr = "someuserspecifiedconnectionstring"
+    c = IMSClient(
+        datasource="whatever",
+        host="host",
+        imstype="ip21",
+        handler_options={"connection_string": connstr},
+    )
+    assert c.handler.generate_connection_string() == connstr
 
 
 @pytest.mark.skipif(

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -52,6 +52,9 @@ def test_get_missing_intervals():
     )
 
 
+@pytest.mark.skipif(
+    is_GITHUBACTION, reason="ODBC drivers unavailable in GitHub Actions"
+)
 def test_PI_init_odbc_client_with_host_port():
     host = "thehostname"
     port = 999
@@ -63,6 +66,9 @@ def test_PI_init_odbc_client_with_host_port():
     assert c.handler.port == port
 
 
+@pytest.mark.skipif(
+    is_GITHUBACTION, reason="ODBC drivers unavailable in GitHub Actions"
+)
 def test_IP21_init_odbc_client_with_host_port():
     host = "thehostname"
     port = 999
@@ -74,6 +80,9 @@ def test_IP21_init_odbc_client_with_host_port():
     assert c.handler.port == port
 
 
+@pytest.mark.skipif(
+    is_GITHUBACTION, reason="ODBC drivers unavailable in GitHub Actions"
+)
 def test_PI_connection_string_override():
     connstr = "someuserspecifiedconnectionstring"
     c = IMSClient(
@@ -85,6 +94,9 @@ def test_PI_connection_string_override():
     assert c.handler.generate_connection_string() == connstr
 
 
+@pytest.mark.skipif(
+    is_GITHUBACTION, reason="ODBC drivers unavailable in GitHub Actions"
+)
 def test_IP21_connection_string_override():
     connstr = "someuserspecifiedconnectionstring"
     c = IMSClient(

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -52,6 +52,28 @@ def test_get_missing_intervals():
     )
 
 
+def test_init_PI_odbc_client_with_host_port():
+    host = 'thehostname'
+    port = 999
+    c = IMSClient(datasource='whatever', imstype='pi', host=host)
+    assert c.handler.host == host
+    assert c.handler.port == 5450
+    c = IMSClient(datasource='whatever', imstype='pi', host=host, port=port)
+    assert c.handler.host == host
+    assert c.handler.port == port
+
+
+def test_init_IP21_odbc_client_with_host_port():
+    host = 'thehostname'
+    port = 999
+    c = IMSClient(datasource='whatever', imstype='ip21', host=host)
+    assert c.handler.host == host
+    assert c.handler.port == 10014
+    c = IMSClient(datasource='whatever', imstype='ip21', host=host, port=port)
+    assert c.handler.host == host
+    assert c.handler.port == port
+
+
 @pytest.mark.skipif(
     is_GITHUBACTION, reason="ODBC drivers unavailable in GitHub Actions"
 )


### PR DESCRIPTION
For some installations, the relevant Windows registry entries containing mapping from ODBC datasource to host and port do not exist. E.g. servers or old installations.

This PR allows the user to explicitly specify the parameters _host_ and _port_ on client creation, this skipping the registry search. If only host is provided, port will be set to a default value (10014 for IP21, 5450 for PI).

The PR also adds the option to specify _connection_string_ as part of _handler_options_. This should only to be used by highly experienced users that know exactly what they are doing where tagreader's default connection string generation does not meet their needs. There is no guarantee that tagreader will not break in obvious or hidden ways, e.g. by using wrong time zones, if the connection string is not correctly provided. 