### PR TITLE
Fix azure pipelines fail on coverage.xml in use

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,7 @@ steps:
     coverage erase
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
-  condition: or(eq(python.version, '3.6'), eq($(python.version, '3.6')), eq(variables['python.version'], '3.6'))
+  condition: or(eq(python.version, '3.6'), eq($(python.version), '3.6'), eq(variables['python.version'], '3.6'))
   displayName: 'Run tests with coverage'
   env: 
     HTTPS_PROXY: $(var_http_proxy)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,20 +40,20 @@ steps:
     coverage erase
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
-  condition: eq('${{ python.version }}', '3.6')
+  condition: eq(variables.python.version, '3.6')
   displayName: 'Run tests with coverage'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - script: |
     pytest tests extratests
-  condition: not(eq('${{ python.version }}', '3.6'))
+  condition: not(eq(variables.python.version, '3.6'))
   displayName: 'Run tests'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - task: PublishCodeCoverageResults@1
-  condition: eq('${{ python.version }}', '3.6')
+  condition: eq(variables.python.version, '3.6')
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,7 @@ steps:
 
 - script: |
     coverage erase
+    rm coverage.xml
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
   condition: eq(variables['python.version'], '3.6')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,7 +40,9 @@ steps:
     coverage erase
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
-  condition: or(eq(python.version, '3.6'), eq($(python.version), '3.6'), eq(variables['python.version'], '3.6'))
+  #condition: eq(python.version, '3.6')
+  #condition: eq($(python.version), '3.6')
+  condition: eq(variables['python.version'], '3.6'))
   displayName: 'Run tests with coverage'
   env: 
     HTTPS_PROXY: $(var_http_proxy)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,11 +40,20 @@ steps:
     coverage erase
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
+  condition: eq($(python.version), '3.6')
+  displayName: 'Run tests with coverage'
+  env: 
+    HTTPS_PROXY: $(var_http_proxy)
+
+- script: |
+    pytest tests extratests
+  condition: not(eq($(python.version), '3.6'))
   displayName: 'Run tests'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - task: PublishCodeCoverageResults@1
+  condition: eq($(python.version), '3.6')
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ steps:
     HTTPS_PROXY: $(var_http_proxy)
 
 - task: PublishCodeCoverageResults@1
-  condition: eq(variables['python.version'], '13.6')
+  condition: eq(variables['python.version'], '3.6')
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -50,7 +50,6 @@ steps:
 - script: |
     echo $(python.version)
     pytest tests extratests
-  condition: not(eq($(python.version), '3.6'))
   displayName: 'Run tests'
   env: 
     HTTPS_PROXY: $(var_http_proxy)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,10 +8,10 @@ strategy:
   matrix:
     Python36:
       python.version: '3.6'
-#    Python37:
-#      python.version: '3.7'
-#    Python38:
-#      python.version: '3.8'
+    Python37:
+      python.version: '3.7'
+    Python38:
+      python.version: '3.8'
 
 steps:
 - task: UsePythonVersion@0
@@ -40,8 +40,6 @@ steps:
     coverage erase
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
-  #condition: eq(python.version, '3.6')
-  #condition: eq($(python.version), '3.6')
   condition: eq(variables['python.version'], '3.6')
   displayName: 'Run tests with coverage'
   env: 
@@ -50,6 +48,7 @@ steps:
 - script: |
     echo $(python.version)
     pytest tests extratests
+  condition: not(eq(variables['python.version'], '3.6'))
   displayName: 'Run tests'
   env: 
     HTTPS_PROXY: $(var_http_proxy)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ steps:
     HTTPS_PROXY: $(var_http_proxy)
 
 - task: PublishCodeCoverageResults@1
-  condition: eq(variables['python.version'], '3.6')
+  condition: eq(variables['python.version'], '13.6')
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,20 +40,18 @@ steps:
     coverage erase
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
-  condition: eq(python.version, '3.6')
+  condition: $[ eq($(python.version), '3.6') ]
   displayName: 'Run tests with coverage'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - script: |
     pytest tests extratests
-  condition: not(eq(python.version, '3.6'))
   displayName: 'Run tests'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - task: PublishCodeCoverageResults@1
-  condition: eq(python.version, '3.6')
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ steps:
     del /f coverage.xml
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
-  condition: eq(variables['python.version'], '3.6')
+  condition: and(succeeded(), eq(variables['python.version'], '3.6'))
   displayName: 'Run tests with coverage'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
@@ -49,13 +49,13 @@ steps:
 - script: |
     echo $(python.version)
     pytest tests extratests
-  condition: not(eq(variables['python.version'], '3.6'))
+  condition: and(succeeded(), not(eq(variables['python.version'], '3.6')))
   displayName: 'Run tests'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - task: PublishCodeCoverageResults@1
-  condition: eq(variables['python.version'], '3.6')
+  condition: and(succeeded(), eq(variables['python.version'], '3.6'))
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,7 +42,7 @@ steps:
     coverage xml --include='tagreader/*'
   #condition: eq(python.version, '3.6')
   #condition: eq($(python.version), '3.6')
-  condition: eq(variables['python.version'], '3.6'))
+  condition: eq(variables['python.version'], '3.6')
   displayName: 'Run tests with coverage'
   env: 
     HTTPS_PROXY: $(var_http_proxy)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,20 +40,20 @@ steps:
     coverage erase
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
-  condition: eq($(python.version), '3.6')
+  condition: eq(python.version, '3.6')
   displayName: 'Run tests with coverage'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - script: |
     pytest tests extratests
-  condition: not(eq($(python.version), '3.6'))
+  condition: not(eq(python.version, '3.6'))
   displayName: 'Run tests'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - task: PublishCodeCoverageResults@1
-  condition: eq($(python.version), '3.6')
+  condition: eq(python.version, '3.6')
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,7 +55,7 @@ steps:
     HTTPS_PROXY: $(var_http_proxy)
 
 - task: PublishCodeCoverageResults@1
-  condition: eq(variables['python.version'], '3.6')
+  condition: eq(variables['python.version'], '13.6')
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,10 +8,10 @@ strategy:
   matrix:
     Python36:
       python.version: '3.6'
-#    Python37:
-#      python.version: '3.7'
-#    Python38:
-#      python.version: '3.8'
+    Python37:
+      python.version: '3.7'
+    Python38:
+      python.version: '3.8'
 
 steps:
 - task: UsePythonVersion@0
@@ -55,7 +55,7 @@ steps:
     HTTPS_PROXY: $(var_http_proxy)
 
 - task: PublishCodeCoverageResults@1
-  condition: eq(variables['python.version'], '13.6')
+  condition: eq(variables['python.version'], '3.6')
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,18 +40,20 @@ steps:
     coverage erase
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
-  condition: $[ eq($(python.version), '3.6') ]
+  condition: eq('$(python.version)', '3.6')
   displayName: 'Run tests with coverage'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - script: |
     pytest tests extratests
+  condition: not(eq('$(python.version)', '3.6'))
   displayName: 'Run tests'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - task: PublishCodeCoverageResults@1
+  condition: eq('$(python.version)', '3.6')
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ steps:
 
 - script: |
     coverage erase
-    rm coverage.xml
+    del /f coverage.xml
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
   condition: eq(variables['python.version'], '3.6')

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,10 +8,10 @@ strategy:
   matrix:
     Python36:
       python.version: '3.6'
-    Python37:
-      python.version: '3.7'
-    Python38:
-      python.version: '3.8'
+#    Python37:
+#      python.version: '3.7'
+#    Python38:
+#      python.version: '3.8'
 
 steps:
 - task: UsePythonVersion@0
@@ -40,20 +40,20 @@ steps:
     coverage erase
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
-  condition: eq('$(python.version)', '3.6')
+  condition: eq('${{ python.version }}', '3.6')
   displayName: 'Run tests with coverage'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - script: |
     pytest tests extratests
-  condition: not(eq('$(python.version)', '3.6'))
+  condition: not(eq('${{ python.version }}', '3.6'))
   displayName: 'Run tests'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - task: PublishCodeCoverageResults@1
-  condition: eq('$(python.version)', '3.6')
+  condition: eq('${{ python.version }}', '3.6')
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,6 +46,8 @@ steps:
     HTTPS_PROXY: $(var_http_proxy)
 
 - script: |
+    echo $(python.version)
+    echo $(variables.python.version)
     pytest tests extratests
   condition: not(eq(variables.python.version, '3.6'))
   displayName: 'Run tests'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,10 +8,10 @@ strategy:
   matrix:
     Python36:
       python.version: '3.6'
-    Python37:
-      python.version: '3.7'
-    Python38:
-      python.version: '3.8'
+#    Python37:
+#      python.version: '3.7'
+#    Python38:
+#      python.version: '3.8'
 
 steps:
 - task: UsePythonVersion@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -54,7 +54,7 @@ steps:
     HTTPS_PROXY: $(var_http_proxy)
 
 - task: PublishCodeCoverageResults@1
-  condition: eq(variables.python.version, '3.6')
+  condition: eq(variables['python.version'], '3.6')
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,16 +40,15 @@ steps:
     coverage erase
     coverage run -m pytest tests extratests
     coverage xml --include='tagreader/*'
-  condition: eq(variables.python.version, '3.6')
+  condition: or(eq(python.version, '3.6'), eq($(python.version, '3.6')), eq(variables['python.version'], '3.6'))
   displayName: 'Run tests with coverage'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
 - script: |
     echo $(python.version)
-    echo $(variables.python.version)
     pytest tests extratests
-  condition: not(eq(variables.python.version, '3.6'))
+  condition: not(eq($(python.version), '3.6'))
   displayName: 'Run tests'
   env: 
     HTTPS_PROXY: $(var_http_proxy)


### PR DESCRIPTION
Fix Azure pipelines that fails due to coverage.xml reportedly being in use by another process.

Now only run coverage tests for 3.6 and ensure coverage.xml is removed before running the coverage tests.