### PR TITLE
Update tables requirement, remove 3.9 warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ will) be modified to work on Linux using REST APIs.
 
 ## Requirements
 
-Python >=3.7 (*) with the following packages:
+Python >=3.7 with the following packages:
 
   + pandas >= 1.0.0
-  + tables (*)
+  + tables
   + requests
   + requests-kerberos
   + certifi >= 2020.04.05
@@ -35,9 +35,6 @@ If using ODBC connections, you must also install proprietary drivers for
 PI ODBC and/or Aspen IP.21 SQLPlus. These drivers are only available for
 Microsoft Windows.
 
-*) Please note that for Python 3.9 there are currently no [Windows wheels
-available](https://github.com/PyTables/PyTables/issues/823) for the tables 
-package. Tagreader will still function, but the cache will be disabled.
 
 ## Installation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ requests-kerberos==0.12.0
     # via -r requirements.in
 six==1.16.0
     # via python-dateutil
-tables==3.6.1 ; platform_system == "Linux" or python_version < "3.9"
+tables==3.7.0
     # via -r requirements.in
 urllib3==1.26.6
     # via requests

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -268,17 +268,7 @@ class IMSClient:
             try:
                 import tables  # noqa: F401
             except ModuleNotFoundError:
-                import sys
-                warning = "Disabling cache due to missing package 'tables'"
-                if (
-                    sys.version_info >= (3, 9)
-                    and sys.platform == "win32"
-                ):
-                    warning += (
-                        "\ntables is currently not available for Python 3.9 for Windows"
-                        "\nMore info: https://github.com/PyTables/PyTables/issues/823"
-                    )
-                warnings.warn(warning)
+                warnings.warn("Disabling cache due to missing package 'tables'")
                 self.cache = None
 
         self.handler.connect()


### PR DESCRIPTION
Tables was updated in [December 2021](https://github.com/PyTables/PyTables/issues/823) to cover Python 3.9. This PR updates `requirements.txt` with the latest tables version, and removes the warning in `clients.py`.

Note I didn't touch `requirements.in`. I'm not sure how that one is used.