### PR TITLE
Fix pandas warnings

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,31 +25,33 @@ steps:
 - script: |
     python -m pip install --upgrade pip
     pip install -r requirements.in
-    pip install pytest pytest-azurepipelines coverage
+    pip install pytest pytest-azurepipelines pytest-cov
   displayName: 'Install dependencies'
   env: 
     HTTPS_PROXY: $(var_http_proxy)
 
-- script: |
-    coverage erase
-    del /f coverage.xml
-    coverage run -m pytest
-    coverage xml --include='tagreader/*'
-  condition: and(succeeded(), eq(variables['python.version'], '3.10'))
-  displayName: 'Run tests with coverage'
-  env: 
-    HTTPS_PROXY: $(var_http_proxy)
+# - script: |
+#     coverage erase
+#     del /f coverage.xml
+#     coverage run -m pytest
+#     coverage xml --include='tagreader/*'
+#   condition: and(succeeded(), eq(variables['python.version'], '3.10'))
+#   displayName: 'Run tests with coverage'
+#   env: 
+#     HTTPS_PROXY: $(var_http_proxy)
 
 - script: |
     echo $(python.version)
-    pytest
-  condition: and(succeeded(), not(eq(variables['python.version'], '3.10')))
+    pytest --junitxml=junit/test-results.xml --cov=tagreader --cov-report=xml
   displayName: 'Run tests'
-  env: 
-    HTTPS_PROXY: $(var_http_proxy)
+
+- task: PublishTestResults@2
+  condition: succeededOrFailed()
+  inputs:
+    testResultsFiles: '**/test-*.xml'
+    testRunTitle: 'Publish test results for Python $(python.version)'
 
 - task: PublishCodeCoverageResults@1
-  condition: and(succeeded(), eq(variables['python.version'], '3.10'))
   inputs:
     codeCoverageTool: Cobertura
     summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,8 @@
 [pytest]
 filterwarnings = 
     error
-    # ignore::urllib3.exceptions.InsecureRequestWarning
     ignore::ResourceWarning
+
 junit_family = xunit1
 python_files = test_*.py
 testpaths = 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,8 @@
 [pytest]
-filterwarnings = error
+filterwarnings = 
+    error
+    # ignore::urllib3.exceptions.InsecureRequestWarning
+    ignore::ResourceWarning
 junit_family = xunit1
 python_files = test_*.py
 testpaths = 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+filterwarnings = error
 junit_family = xunit1
 python_files = test_*.py
 testpaths = 

--- a/tagreader/web_handlers.py
+++ b/tagreader/web_handlers.py
@@ -237,7 +237,8 @@ class AspenHandlerWeb:
             self.verify_connection(self.datasource)
         except requests.ConnectionError:
             raise ConnectionError(
-                f"Not able to connect to {self.base_url}. Check network connection.") from None
+                f"Not able to connect to {self.base_url}. Check network connection."
+            ) from None
 
     @staticmethod
     def split_tagmap(tagmap):
@@ -709,7 +710,8 @@ class PIHandlerWeb:
             self.verify_connection(self.datasource)
         except requests.ConnectionError:
             raise ConnectionError(
-                f"Not able to connect to {self.base_url}. Check network connection.") from None
+                f"Not able to connect to {self.base_url}. Check network connection."
+            ) from None
 
     def search(self, tag=None, desc=None):
         params = self.generate_search_query(tag, desc, self.datasource)
@@ -891,9 +893,9 @@ class PIHandlerWeb:
         if get_status:
             df["Status"] = (
                 # Values are boolean, but no need to do .astype(int)
-                df["Questionable"] +
-                2 * (1 - df["Good"]) +
-                4 * df["Substituted"]
+                df["Questionable"]
+                + 2 * (1 - df["Good"])
+                + 4 * df["Substituted"]
             )
             df = df.drop(columns=["Good", "Questionable", "Substituted"])
 

--- a/tests/test_AspenHandlerREST_connect.py
+++ b/tests/test_AspenHandlerREST_connect.py
@@ -1,6 +1,7 @@
 import os
 
 import pytest
+import urllib3
 from pytest import raises
 from tagreader.clients import IMSClient, list_sources
 from tagreader.web_handlers import AspenHandlerWeb, get_verifySSL, list_aspenone_sources
@@ -15,6 +16,8 @@ if is_GITHUBACTION:
     )
 
 verifySSL = False if is_AZUREPIPELINE else get_verifySSL()
+if is_AZUREPIPELINE:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 SOURCE = "SNA"
 TAG = "ATCAI"

--- a/tests/test_AspenHandlerREST_connect.py
+++ b/tests/test_AspenHandlerREST_connect.py
@@ -1,7 +1,6 @@
 import os
 
 import pytest
-import urllib3
 from pytest import raises
 from tagreader.clients import IMSClient, list_sources
 from tagreader.web_handlers import AspenHandlerWeb, get_verifySSL, list_aspenone_sources
@@ -16,8 +15,6 @@ if is_GITHUBACTION:
     )
 
 verifySSL = False if is_AZUREPIPELINE else get_verifySSL()
-if is_AZUREPIPELINE:
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 SOURCE = "SNA"
 TAG = "ATCAI"

--- a/tests/test_PIHandlerODBC_connect.py
+++ b/tests/test_PIHandlerODBC_connect.py
@@ -59,19 +59,18 @@ def test_list_sources_pi():
         assert 3 <= len(r)
 
 
-def test_search(Client):
-    res = Client.search("BA:*.1")
-    assert 5 == len(res)
+def test_search_tag(Client):
+    res = Client.search("SINUSOID")
+    assert 1 == len(res)
+    res = Client.search("SIN*")
+    assert 3 <= len(res)
     [taglist, desclist] = zip(*res)
-    assert "BA:CONC.1" in taglist
-    assert desclist[taglist.index("BA:CONC.1")] == "Concentration Reactor 1"
-
-    res = Client.search(tag="BA:*.1")
-    assert 5 == len(res)
-    res = Client.search(desc="Batch Active Reactor 1")
-    assert 1 == len(res)
-    res = Client.search("BA*.1", "*Active*")
-    assert 1 == len(res)
+    assert "SINUSOIDU" in taglist
+    assert desclist[taglist.index("SINUSOID")] == "12 Hour Sine Wave"
+    res = Client.search(desc="12 Hour Sine Wave")
+    assert 1 <= len(res)
+    res = Client.search("SINUSOID", desc="*Sine*")
+    assert 1 <= len(res)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_PIHandlerREST_connect.py
+++ b/tests/test_PIHandlerREST_connect.py
@@ -1,8 +1,8 @@
 import os
-import sys
 
 import pandas as pd
 import pytest
+import urllib3
 from tagreader.clients import IMSClient, list_sources
 from tagreader.utils import ReaderType, ensure_datetime_with_tz
 from tagreader.web_handlers import PIHandlerWeb, get_verifySSL, list_piwebapi_sources
@@ -16,6 +16,8 @@ if is_GITHUBACTION:
     )
 
 verifySSL = False if is_AZUREPIPELINE else get_verifySSL()
+if is_AZUREPIPELINE:
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 BASE_URL = "https://piwebapi.equinor.com/piwebapi"
 SOURCE = "PIMAM"

--- a/tests/test_PIHandlerREST_connect.py
+++ b/tests/test_PIHandlerREST_connect.py
@@ -19,7 +19,9 @@ if is_GITHUBACTION:
 verifySSL = False if is_AZUREPIPELINE else get_verifySSL()
 if is_AZUREPIPELINE:
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    warnings.filterwarnings("ignore", urllib3.exceptions.InsecureRequestWarning)
+    warnings.filterwarnings(
+        "ignore", category=urllib3.exceptions.InsecureRequestWarning
+    )
 
 BASE_URL = "https://piwebapi.equinor.com/piwebapi"
 SOURCE = "PIMAM"

--- a/tests/test_PIHandlerREST_connect.py
+++ b/tests/test_PIHandlerREST_connect.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 
 import pandas as pd
 import pytest
@@ -17,11 +16,6 @@ if is_GITHUBACTION:
     )
 
 verifySSL = False if is_AZUREPIPELINE else get_verifySSL()
-if is_AZUREPIPELINE:
-    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-    warnings.filterwarnings(
-        "ignore", category=urllib3.exceptions.InsecureRequestWarning
-    )
 
 BASE_URL = "https://piwebapi.equinor.com/piwebapi"
 SOURCE = "PIMAM"
@@ -80,16 +74,14 @@ def test_verify_connection(PIHandler):
 def test_search_tag(Client):
     res = Client.search("SINUSOID")
     assert 1 == len(res)
-    res = Client.search("BA:*.1")
-    assert 5 <= len(res)
+    res = Client.search("SIN*")
+    assert 3 <= len(res)
     [taglist, desclist] = zip(*res)
-    assert "BA:CONC.1" in taglist
-    assert desclist[taglist.index("BA:CONC.1")] == "Concentration Reactor 1"
-    res = Client.search(tag="BA:*.1")
-    assert 5 <= len(res)
-    res = Client.search(desc="Concentration Reactor 1")
+    assert "SINUSOIDU" in taglist
+    assert desclist[taglist.index("SINUSOID")] == "12 Hour Sine Wave"
+    res = Client.search(desc="12 Hour Sine Wave")
     assert 1 <= len(res)
-    res = Client.search("BA*.1", "*Active*")
+    res = Client.search("SINUSOID", desc="*Sine*")
     assert 1 <= len(res)
 
 

--- a/tests/test_PIHandlerREST_connect.py
+++ b/tests/test_PIHandlerREST_connect.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import pandas as pd
 import pytest
@@ -18,6 +19,7 @@ if is_GITHUBACTION:
 verifySSL = False if is_AZUREPIPELINE else get_verifySSL()
 if is_AZUREPIPELINE:
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    warnings.filterwarnings("ignore", urllib3.exceptions.InsecureRequestWarning)
 
 BASE_URL = "https://piwebapi.equinor.com/piwebapi"
 SOURCE = "PIMAM"


### PR DESCRIPTION
Pandas recently started to complain:
```UserWarning: pandas only support SQLAlchemy connectable(engine/connection) ordatabase string URI or sqlite3 DBAPI2 connectionother DBAPI2 objects are not tested, please consider using SQLAlchemy```

Apparently this still works, so I see no  need to add SQLAlchemy as a dependency. Ignore the warning instead.

Since users find warnings annoying, treat warnings as errors to suppress them before new releases.