### PR TITLE
bugfix: don't call unavailable functions on mac

### DIFF
--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -40,7 +40,7 @@ def list_sources(imstype, url=None, auth=None, verifySSL=None):
     if imstype is None or imstype.lower() not in accepted_values:
         import platform
         raise ValueError(
-            f"Input `imstype` must be one of {accepted_values} when called from an {platform.system()} environment.")
+            f"Input `imstype` must be one of {accepted_values} when called from {platform.system()} environment.")
     
     if imstype.lower() == "pi":
         return list_pi_sources()

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -6,32 +6,17 @@ from operator import itemgetter
 import pandas as pd
 
 from .cache import BucketCache, SmartCache
-from .utils import (
-    ReaderType,
-    ensure_datetime_with_tz,
-    find_registry_key,
-    find_registry_key_from_name,
-    is_windows,
-    logging,
-)
-from .web_handlers import (
-    AspenHandlerWeb,
-    PIHandlerWeb,
-    get_auth_aspen,
-    get_auth_pi,
-    list_aspenone_sources,
-    list_piwebapi_sources,
-)
+from .utils import (ReaderType, ensure_datetime_with_tz, find_registry_key,
+                    find_registry_key_from_name, is_windows, logging)
+from .web_handlers import (AspenHandlerWeb, PIHandlerWeb, get_auth_aspen,
+                           get_auth_pi, list_aspenone_sources,
+                           list_piwebapi_sources)
 
 if is_windows():
     import pyodbc
 
-    from .odbc_handlers import (
-        AspenHandlerODBC,
-        PIHandlerODBC,
-        list_aspen_sources,
-        list_pi_sources,
-    )
+    from .odbc_handlers import (AspenHandlerODBC, PIHandlerODBC,
+                                list_aspen_sources, list_pi_sources)
     from .utils import winreg
 
 logging.basicConfig(
@@ -47,10 +32,16 @@ warnings.simplefilter("always", DuplicateTagsWarning)
 
 
 def list_sources(imstype, url=None, auth=None, verifySSL=None):
-    accepted_values = ["pi", "aspen", "ip21", "piwebapi", "aspenone"]
-    if not imstype or imstype.lower() not in accepted_values:
-        raise ValueError(f"`imstype` must be one of {accepted_values}")
+    accepted_values = ["piwebapi", "aspenone"]
+    win_accepted_values = ["pi", "aspen", "ip21"]
+    if is_windows():
+        accepted_values.extend(win_accepted_values)
 
+    if imstype is None or imstype.lower() not in accepted_values:
+        import platform
+        raise ValueError(
+            f"Input `imstype` must be one of {accepted_values} when called from an {platform.system()} environment.")
+    
     if imstype.lower() == "pi":
         return list_pi_sources()
     elif imstype.lower() in ["aspen", "ip21"]:
@@ -120,6 +111,9 @@ def get_server_address_aspen(datasource):
     host and port based on the path above and the UUID.
     """
 
+    if not is_windows():
+        return None
+
     regkey_clsid = winreg.OpenKey(
         winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Classes\Wow6432Node\CLSID"
     )
@@ -156,6 +150,10 @@ def get_server_address_pi(datasource):
     :return: host, port
     :type: tuple(string, int)
     """
+
+    if not is_windows():
+        return None
+
     try:
         reg_key = winreg.OpenKey(
             winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Wow6432Node\PISystem\PI-SDK"


### PR DESCRIPTION
list_pi_sources and list_aspen_sources is unavailable on mac.
get_server_address_aspen and get_server_address_pi depends on windows registry and will only return results on windows systems.