### PR TITLE
fix: timestamp parsing for Pandas 2.0

### DIFF
--- a/tagreader/utils.py
+++ b/tagreader/utils.py
@@ -65,7 +65,10 @@ def find_registry_key_from_name(base_key, search_key_name):
 
 def ensure_datetime_with_tz(date_stamp, tz="Europe/Oslo"):
     if isinstance(date_stamp, str):
-        date_stamp = pd.to_datetime(date_stamp, dayfirst=True)
+        try:
+            date_stamp = pd.to_datetime(date_stamp, format="ISO8601")
+        except ValueError:
+            date_stamp = pd.to_datetime(date_stamp, dayfirst=True)
 
     if not date_stamp.tzinfo:
         date_stamp = pytz.timezone(tz).localize(date_stamp)
@@ -148,8 +151,11 @@ def add_statoil_root_certificate(noisy=True):
                 break
     elif is_mac():
         import subprocess
-        macos_ca_certs = subprocess.run(["security", "find-certificate", "-a", "-c", "Statoil Root CA", "-Z"],
-                                        stdout=subprocess.PIPE).stdout
+
+        macos_ca_certs = subprocess.run(
+            ["security", "find-certificate", "-a", "-c", "Statoil Root CA", "-Z"],
+            stdout=subprocess.PIPE,
+        ).stdout
 
         if STATOIL_ROOT_PEM_HASH.upper() in str(macos_ca_certs).upper():
             c = get_macos_statoil_certificates()
@@ -184,8 +190,10 @@ def get_macos_statoil_certificates():
 
     ctx = ssl.create_default_context()
     macos_ca_certs = subprocess.run(
-        ["security", "find-certificate", "-a", "-c", "Statoil Root CA", "-p"], stdout=subprocess.PIPE).stdout
-    with tempfile.NamedTemporaryFile('w+b') as tmp_file:
+        ["security", "find-certificate", "-a", "-c", "Statoil Root CA", "-p"],
+        stdout=subprocess.PIPE,
+    ).stdout
+    with tempfile.NamedTemporaryFile("w+b") as tmp_file:
         tmp_file.write(macos_ca_certs)
         ctx.load_verify_locations(tmp_file.name)
 
@@ -215,7 +223,9 @@ def is_equinor() -> bool:
             return True
     elif is_mac():
         s = subprocess.run(
-            ["security", "find-certificate", "-a", "-c" "client.statoil.net"], stdout=subprocess.PIPE).stdout
+            ["security", "find-certificate", "-a", "-c" "client.statoil.net"],
+            stdout=subprocess.PIPE,
+        ).stdout
 
         host = socket.gethostname()
 
@@ -229,5 +239,6 @@ def is_equinor() -> bool:
                 return True
     else:
         raise OSError(
-            f"Unsupported system: {platform.system()}. Please report this as an issue.")
+            f"Unsupported system: {platform.system()}. Please report this as an issue."
+        )
     return False


### PR DESCRIPTION
Seems like parsing changed with Pandas 2, so it is not possible to correctly parse both of these using dayfirst=True:
2020-04-01
01.04.2020
Before both were correctly parsed to April 1st 2020 (yes, Tagreader uses European notation), but now 2020-04-01 is incorrectly parsed to January 4th 2020.

Fixed by trying to handle ISO8601-like formats first, and if that fails try to parse as before.