### PR TITLE
fix: do not throw error when start and end time is submitted when using SNAPSHOT and ODBC connectors

### DIFF
--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -201,7 +201,7 @@ def get_server_address_pi(datasource: str) -> Optional[Tuple[str, int]]:
 
 
 def get_handler(
-    imstype: IMSType,
+    imstype: Optional[IMSType],
     datasource: str,
     url: Optional[str],
     host: Optional[str],
@@ -283,6 +283,11 @@ def get_handler(
             verifySSL=verifySSL,
             auth=auth,
         )
+
+    raise ValueError(
+        f"Could not infer IMSType for datasource: {datasource}."
+        f"Please specify correct datasource, imstype or host, or refer to the user docs."
+    )
 
 
 class IMSClient:

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -17,7 +17,7 @@ from tagreader.utils import (
     ensure_datetime_with_tz,
     find_registry_key,
     find_registry_key_from_name,
-    is_windows,
+    is_windows, convert_to_pydatetime,
 )
 from tagreader.web_handlers import (
     AspenHandlerWeb,
@@ -571,13 +571,13 @@ class IMSClient:
             start_time = NONE_START_TIME
         elif isinstance(start_time, (str, pd.Timestamp)):
             try:
-                start_time = ensure_datetime_with_tz(start_time)
+                start_time = convert_to_pydatetime(start_time)
             except ValueError:
-                start_time = ensure_datetime_with_tz(start_time)
+                start_time = convert_to_pydatetime(start_time)
         if end_time is None:
             end_time = datetime.utcnow()
         elif isinstance(end_time, (str, pd.Timestamp)):
-            end_time = ensure_datetime_with_tz(end_time)
+            end_time = convert_to_pydatetime(end_time)
 
         if isinstance(ts, pd.Timedelta):
             ts = ts.to_pytimedelta()

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -14,10 +14,11 @@ from tagreader.logger import logger
 from tagreader.utils import (
     IMSType,
     ReaderType,
+    convert_to_pydatetime,
     ensure_datetime_with_tz,
     find_registry_key,
     find_registry_key_from_name,
-    is_windows, convert_to_pydatetime,
+    is_windows,
 )
 from tagreader.web_handlers import (
     AspenHandlerWeb,

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -499,8 +499,8 @@ class IMSClient:
     def read_tags(
         self,
         tags: Union[str, List[str]],
-        start_time: Optional[Union[datetime, pd.Timestamp, str]],
-        stop_time: Optional[Union[datetime, pd.Timestamp, str]],
+        start_time: Optional[Union[datetime, pd.Timestamp, str]] = None,
+        stop_time: Optional[Union[datetime, pd.Timestamp, str]] = None,
         ts: Optional[Union[timedelta, pd.Timedelta]] = timedelta(seconds=60),
         read_type: ReaderType = ReaderType.INT,
         get_status: bool = False,
@@ -523,8 +523,8 @@ class IMSClient:
     def read(
         self,
         tags: Union[str, List[str]],
-        start_time: Optional[Union[datetime, pd.Timestamp, str]],
-        end_time: Optional[Union[datetime, pd.Timestamp, str]],
+        start_time: Optional[Union[datetime, pd.Timestamp, str]] = None,
+        end_time: Optional[Union[datetime, pd.Timestamp, str]] = None,
         ts: Union[timedelta, pd.Timedelta, int] = timedelta(seconds=60),
         read_type: ReaderType = ReaderType.INT,
         get_status: bool = False,

--- a/tagreader/clients.py
+++ b/tagreader/clients.py
@@ -566,13 +566,13 @@ class IMSClient:
             start_time = NONE_START_TIME
         elif isinstance(start_time, (str, pd.Timestamp)):
             try:
-                start_time = datetime.fromisoformat(str(start_time))
+                start_time = ensure_datetime_with_tz(start_time)
             except ValueError:
-                start_time = datetime.fromisoformat(str(start_time))
+                start_time = ensure_datetime_with_tz(start_time)
         if end_time is None:
             end_time = datetime.utcnow()
         elif isinstance(end_time, (str, pd.Timestamp)):
-            end_time = datetime.fromisoformat(str(end_time))
+            end_time = ensure_datetime_with_tz(end_time)
 
         if isinstance(ts, pd.Timedelta):
             ts = ts.to_pytimedelta()

--- a/tagreader/odbc_handlers.py
+++ b/tagreader/odbc_handlers.py
@@ -8,6 +8,7 @@ import pandas as pd
 import pyodbc
 import pytz
 
+from tagreader.logger import logger
 from tagreader.utils import ReaderType, find_registry_key, logging, winreg
 
 logging.basicConfig(
@@ -112,9 +113,10 @@ class AspenHandlerODBC:
             raise NotImplementedError
 
         if read_type == ReaderType.SNAPSHOT and stop_time is not None:
-            raise NotImplementedError(
-                "Timestamp not supported for IP.21 ODBC connection using 'SNAPSHOT'. "
-                "Try the web API 'aspenone' instead."
+            stop_time = None
+            logger.warning(
+                "End time is not supported for Aspen ODBC connection using 'SNAPSHOT'."
+                "Try the web API 'piwebapi' instead."
             )
 
         seconds = 0
@@ -472,8 +474,9 @@ class PIHandlerODBC:
             raise NotImplementedError
 
         if read_type == ReaderType.SNAPSHOT and stop_time is not None:
-            raise NotImplementedError(
-                "Timestamp not supported for PI ODBC connection using 'SNAPSHOT'."
+            stop_time = None
+            logger.warning(
+                "End time is not supported for PI ODBC connection using 'SNAPSHOT'."
                 "Try the web API 'piwebapi' instead."
             )
 

--- a/tagreader/odbc_handlers.py
+++ b/tagreader/odbc_handlers.py
@@ -214,7 +214,7 @@ class AspenHandlerODBC:
         self.cursor = self.conn.cursor()
 
     @staticmethod
-    def _generate_query_get_mapdef_for_search(tag):
+    def _generate_query_get_mapdef_for_search(tag: str) -> str:
         query = [
             "SELECT DISTINCT a.name as tagname, m.NAME, m.MAP_DefinitionRecord,",
             "m.MAP_IsDefault, m.MAP_Description, m.MAP_Units, m.MAP_Base, m.MAP_Range",
@@ -294,6 +294,9 @@ class AspenHandlerODBC:
         return None
 
     def search(self, tag: Optional[str], desc: Optional[str]) -> List[Tuple[str, str]]:
+        if tag is None:
+            raise ValueError("Tag is a required argument")
+
         tag = tag.replace("*", "%") if isinstance(tag, str) else None
         desc = desc.replace("*", "%") if isinstance(desc, str) else None
 

--- a/tagreader/utils.py
+++ b/tagreader/utils.py
@@ -66,17 +66,25 @@ def find_registry_key_from_name(base_key, search_key_name: str):
     return key, key_string
 
 
+def convert_to_pydatetime(date_stamp: Union[datetime, str, pd.Timestamp]) -> datetime:
+    if isinstance(date_stamp, datetime):
+        return date_stamp
+    elif isinstance(date_stamp, pd.Timestamp):
+        return date_stamp.to_pydatetime()
+    else:
+        try:
+            return pd.to_datetime(
+                str(date_stamp), format="ISO8601"
+            ).to_pydatetime()
+        except ValueError:
+            return pd.to_datetime(str(date_stamp), dayfirst=True).to_pydatetime()
+
+
 def ensure_datetime_with_tz(
     date_stamp: Union[datetime, str, pd.Timestamp],
     tz: pytz.timezone = pytz.timezone("Europe/Oslo"),
 ) -> datetime:
-    if isinstance(date_stamp, (pd.Timestamp, str)):
-        try:
-            date_stamp = pd.to_datetime(
-                str(date_stamp), format="ISO8601"
-            ).to_pydatetime()
-        except ValueError:
-            date_stamp = pd.to_datetime(str(date_stamp), dayfirst=True).to_pydatetime()
+    date_stamp = convert_to_pydatetime(date_stamp)
 
     if not date_stamp.tzinfo:
         date_stamp = tz.localize(date_stamp)

--- a/tagreader/utils.py
+++ b/tagreader/utils.py
@@ -73,9 +73,7 @@ def convert_to_pydatetime(date_stamp: Union[datetime, str, pd.Timestamp]) -> dat
         return date_stamp.to_pydatetime()
     else:
         try:
-            return pd.to_datetime(
-                str(date_stamp), format="ISO8601"
-            ).to_pydatetime()
+            return pd.to_datetime(str(date_stamp), format="ISO8601").to_pydatetime()
         except ValueError:
             return pd.to_datetime(str(date_stamp), dayfirst=True).to_pydatetime()
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -7,9 +7,6 @@ import pytest
 from tagreader.clients import IMSClient, get_missing_intervals, get_next_timeslice
 from tagreader.utils import ReaderType, is_windows
 
-if is_windows():
-    from tagreader.odbc_handlers import AspenHandlerODBC, PIHandlerODBC
-
 is_GITHUBACTION = "GITHUB_ACTION" in os.environ
 is_AZUREPIPELINE = "TF_BUILD" in os.environ
 is_CI = is_GITHUBACTION or is_AZUREPIPELINE
@@ -53,11 +50,6 @@ def test_get_missing_intervals() -> None:
         datetime(2018, 1, 18, 6, 0, 0),
     )
 
-
-@pytest.mark.skipif(
-    is_GITHUBACTION or not is_windows(),
-    reason="ODBC drivers require Windows and are unavailable in GitHub Actions",
-)
 class TestODBC:
     def test_PI_init_odbc_client_with_host_port(self) -> None:
         host = "thehostname"
@@ -111,6 +103,3 @@ class TestODBC:
         with pytest.raises(ValueError):
             c = IMSClient(datasource="sna", imstype="pi")
         c = IMSClient(datasource="onO-iMs", imstype="pi")
-        assert isinstance(c.handler, PIHandlerODBC)
-        c = IMSClient(datasource="snA", imstype="aspen")
-        assert isinstance(c.handler, AspenHandlerODBC)


### PR DESCRIPTION
- Do not throw error when start and end time is submitted when using SNAPSHOT and ODBC connectors
- Set default start and end time to None
- Resolve failing tests
